### PR TITLE
allow local host for health check #23

### DIFF
--- a/JobTrackerApi/Dockerfile
+++ b/JobTrackerApi/Dockerfile
@@ -33,7 +33,9 @@ COPY --from=build /app/publish .
 # --start-period=30s: grace period for app startup before failures count
 # -f: curl exits non-zero on HTTP error responses (4xx/5xx), not just network failures
 # Port 8080: Kestrel's default in the aspnet base image
+# -H "Host: localhost": AllowedHosts in appsettings.Production.json validates the Host header;
+#   localhost is explicitly allowed there for internal health checks
 HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
-    CMD curl -f --max-time 5 --no-verbose http://localhost:8080/health || exit 1
+    CMD curl -f --max-time 5 --no-verbose -H "Host: localhost" http://localhost:8080/health || exit 1
 
 ENTRYPOINT ["dotnet", "JobTrackerApi.dll"]

--- a/JobTrackerApi/appsettings.Production.json
+++ b/JobTrackerApi/appsettings.Production.json
@@ -5,5 +5,5 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "jobtracker.nagarenegishi.com"
+  "AllowedHosts": "jobtracker.nagarenegishi.com;localhost" 
 }


### PR DESCRIPTION
This pull request updates the application's production configuration and Docker health check to better support internal health checks by allowing requests from `localhost`. The main changes ensure that the health check endpoint can be accessed internally, which is important for container orchestration and monitoring.

Configuration changes for internal health checks:

* Added `localhost` to the `AllowedHosts` setting in `appsettings.Production.json` to permit health check requests from within the container.

Docker health check improvements:

* Updated the Dockerfile health check command to include a `Host: localhost` header in the curl request, aligning with the new `AllowedHosts` configuration.