### PR TITLE
Implement parsing service and update progress for job listings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,9 @@ DEMO_RESET_KEY=your-long-random-reset-key
 # Transactional email sender address and Resend API key
 EMAIL_FROM_ADDRESS=noreply@yourdomain.com                                                                                     
 RESEND_API_KEY=your-resend-api-key
-                                                                                                   
+
+# Anthropic API key — used for auto-fill job parsing (POST /api/jobs/parse)
+ANTHROPIC_API_KEY=your-anthropic-api-DEMO_RESET_KEY
+
 # Admin email — existing confirmed user promoted to Admin + AiUser on startup
 ADMIN_EMAIL=admin@example.com

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -178,6 +178,7 @@ jobs:
             export EMAIL_FROM_ADDRESS="${{ secrets.EMAIL_FROM_ADDRESS }}"
             export RESEND_API_KEY="${{ secrets.RESEND_API_KEY }}"
             export ADMIN_EMAIL="${{ secrets.ADMIN_EMAIL }}"
+            export ANTHROPIC_API_KEY="${{ secrets.ANTHROPIC_API_KEY }}"
 
             docker compose -f compose.prod.yml up --no-build -d
           EOF

--- a/JobTrackerApi.Tests/JobsControllerTests.cs
+++ b/JobTrackerApi.Tests/JobsControllerTests.cs
@@ -476,4 +476,20 @@ public class JobsControllerTests: IDisposable
         // Assert: Check that validation fails
         Assert.False(isValid);
     }
+
+    // Test for ParseListingRequest with HTML input
+    [Fact]
+    public async Task ParseListingRequest_HtmlInput_FailsValidation()
+    {
+        // Arrange
+        var request = new ParseListingRequest { Text = "<div>job listing</div>" };
+        var context = new ValidationContext(request);
+        var results = new List<ValidationResult>();
+
+        // Act
+        var isValid = Validator.TryValidateObject(request, context, results, true);
+
+        // Assert: Check that validation fails
+        Assert.False(isValid);
+    }
 }

--- a/JobTrackerApi.Tests/JobsControllerTests.cs
+++ b/JobTrackerApi.Tests/JobsControllerTests.cs
@@ -444,4 +444,20 @@ public class JobsControllerTests: IDisposable
         var jobs = Assert.IsType<List<JobResponseDto>>(result.Value);
         Assert.Empty(jobs);
     }
+
+    // Test for ParseListingRequest with empty text
+    [Fact]
+    public async Task ParseListingRequest_EmptyText_FailsValidation()
+    {
+        // Arrange
+        var request = new ParseListingRequest { Text = "" };
+        var context = new ValidationContext(request);
+        var results = new List<ValidationResult>();
+
+        // Act
+        var isValid = Validator.TryValidateObject(request, context, results, true);
+
+        // Assert: Check that validation fails
+        Assert.False(isValid);
+    }
 }

--- a/JobTrackerApi.Tests/JobsControllerTests.cs
+++ b/JobTrackerApi.Tests/JobsControllerTests.cs
@@ -492,4 +492,27 @@ public class JobsControllerTests: IDisposable
         // Assert: Check that validation fails
         Assert.False(isValid);
     }
+
+    // Test for ParseListing with a partial result
+    [Fact]
+    public async Task ParseListing_ReturnsOk_WithParsedFields()
+    {
+        // Arrange
+        var text = "Senior Engineer at Acme Corp.";
+        var parsed = new ParsedJobFields { Company = "Acme Corp", Role = "Senior Engineer", Description = text };
+        _parsingMock
+            .Setup(s => s.ParseListingAsync(text))
+            .ReturnsAsync(parsed);
+        var request = new ParseListingRequest { Text = text };
+
+        // Act
+        var result = await _controller.ParseListing(request);
+
+        // Assert
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var fields = Assert.IsType<ParsedJobFields>(ok.Value);
+        Assert.Equal("Acme Corp", fields.Company);
+        Assert.Equal("Senior Engineer", fields.Role);
+        Assert.Equal(text, fields.Description);
+    }
 }

--- a/JobTrackerApi.Tests/JobsControllerTests.cs
+++ b/JobTrackerApi.Tests/JobsControllerTests.cs
@@ -460,4 +460,20 @@ public class JobsControllerTests: IDisposable
         // Assert: Check that validation fails
         Assert.False(isValid);
     }
+
+    // Test for ParseListingRequest with text over 8000 characters
+    [Fact]
+    public async Task ParseListingRequest_TextOverLimit_FailsValidation()
+    {
+        // Arrange
+        var request = new ParseListingRequest { Text = new string('x', 8001) };
+        var context = new ValidationContext(request);
+        var results = new List<ValidationResult>();
+
+        // Act
+        var isValid = Validator.TryValidateObject(request, context, results, true);
+
+        // Assert: Check that validation fails
+        Assert.False(isValid);
+    }
 }

--- a/JobTrackerApi.Tests/JobsControllerTests.cs
+++ b/JobTrackerApi.Tests/JobsControllerTests.cs
@@ -14,6 +14,7 @@ public class JobsControllerTests: IDisposable
 {
     private readonly JobTrackerContext _context;
     private readonly Mock<IStorageService> _storageMock;
+    private readonly Mock<IParsingService> _parsingMock;
     private readonly JobsController _controller;
     private const string TestUserId = "test-user-id";
 
@@ -25,10 +26,11 @@ public class JobsControllerTests: IDisposable
             .Options; // .Options extracts the built configuration object
 
         _storageMock = new Mock<IStorageService>();
+        _parsingMock = new Mock<IParsingService>();
 
         // create context and controller directly
         _context = new JobTrackerContext(options);
-        _controller = new JobsController(_context, _storageMock.Object);
+        _controller = new JobsController(_context, _storageMock.Object, _parsingMock.Object);
         SetUser();
     }
 

--- a/JobTrackerApi/Controllers/JobsController.cs
+++ b/JobTrackerApi/Controllers/JobsController.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.JsonPatch.SystemTextJson;
+using Microsoft.AspNetCore.RateLimiting;
 using System.Security.Claims;
 // https://learn.microsoft.com/en-us/aspnet/core/web-api/?view=aspnetcore-10.0
 
@@ -17,11 +18,13 @@ public class JobsController : ControllerBase
 {
     private readonly JobTrackerContext _context; // Assigned once, never changes
     private readonly IStorageService _storage;
+    private readonly IParsingService _parsing;
 
-    public JobsController(JobTrackerContext context, IStorageService storage)
+    public JobsController(JobTrackerContext context, IStorageService storage, IParsingService parsing)
     {
         _context = context;
         _storage = storage;
+        _parsing = parsing;
     }
 
     //NOTE: with UserId, Every action needs two things:

--- a/JobTrackerApi/Controllers/JobsController.cs
+++ b/JobTrackerApi/Controllers/JobsController.cs
@@ -213,11 +213,16 @@ public class JobsController : ControllerBase
         return NoContent();
     }
 
-    // Returns true if the current request is authenticated as the demo account
-    private bool IsDemo() =>
-        User.FindFirstValue(ClaimTypes.Email) == DemoUser.Email;
+    [HttpPost("parse")]
+    [Authorize(Policy = "AiEnabled")]
+    [EnableRateLimiting("parse")]
+    public async Task<ActionResult<ParsedJobFields>> ParseListing([FromBody] ParseListingRequest request)
+    {
+        return Ok(await _parsing.ParseListingAsync(request.Text));
+    }
 
-    // Helper method to check if a job exists by ID
+    // Helper methods
+    // Check if a job exists by ID
     private bool JobsExists(int id)
     {
         return _context.Jobs.Any(e => e.Id == id);

--- a/JobTrackerApi/Controllers/JobsController.cs
+++ b/JobTrackerApi/Controllers/JobsController.cs
@@ -213,6 +213,10 @@ public class JobsController : ControllerBase
         return NoContent();
     }
 
+    // Returns true if the current request is authenticated as the demo account
+    private bool IsDemo() =>
+        User.FindFirstValue(ClaimTypes.Email) == DemoUser.Email;
+
     // Helper method to check if a job exists by ID
     private bool JobsExists(int id)
     {

--- a/JobTrackerApi/JobTrackerApi.csproj
+++ b/JobTrackerApi/JobTrackerApi.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Anthropic" Version="12.23.0" />
+    <PackageReference Include="Anthropic.SDK" Version="5.10.0" />
     <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="4.0.3.26" />
     <PackageReference Include="AWSSDK.S3" Version="4.0.19.1" />
     <PackageReference Include="AWSSDK.SimpleEmailV2" Version="4.0.12.5" />

--- a/JobTrackerApi/JobTrackerApi.csproj
+++ b/JobTrackerApi/JobTrackerApi.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Anthropic" Version="12.23.0" />
     <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="4.0.3.26" />
     <PackageReference Include="AWSSDK.S3" Version="4.0.19.1" />
     <PackageReference Include="AWSSDK.SimpleEmailV2" Version="4.0.12.5" />

--- a/JobTrackerApi/Models/ParseListingRequest.cs
+++ b/JobTrackerApi/Models/ParseListingRequest.cs
@@ -1,0 +1,18 @@
+using System.ComponentModel.DataAnnotations;
+using System.Text.RegularExpressions;
+
+namespace JobTrackerApi.Models;
+
+public class ParseListingRequest : IValidatableObject
+{
+    [Required(AllowEmptyStrings = false)]
+    [MaxLength(8000)]
+    public string Text { get; set; } = string.Empty;
+
+    // HTML in a textarea paste is stripped by the browser — presence signals a crafted request.
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        if (Regex.IsMatch(Text, @"<[a-zA-Z/]"))
+            yield return new ValidationResult("Invalid request.", [nameof(Text)]);
+    }
+}

--- a/JobTrackerApi/Models/ParsedJobFields.cs
+++ b/JobTrackerApi/Models/ParsedJobFields.cs
@@ -2,39 +2,56 @@ using System.Text.Json.Serialization;
 
 namespace JobTrackerApi.Models;
 
-/// <summary>Fields extracted from a raw job listing by the AI parser.</summary>
+/// <summary>
+/// Fields extracted from a raw job listing by the AI parser.
+/// Every property that Claude extracts must have [JsonPropertyName] with the exact key name
+/// from the system prompt. ClaudeParsingService derives its known-keys set from these attributes
+/// via reflection — a property without [JsonPropertyName] is excluded from both deserialization
+/// and the unknown-key logging check. Description is intentionally unannotated: it is set by
+/// the backend directly, not extracted by Claude.
+/// </summary>
 public class ParsedJobFields
 {
     // Null fields are omitted from the JSON response — frontend skips them in the merge step.
+    [JsonPropertyName("company")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? Company { get; set; }
 
+    [JsonPropertyName("role")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? Role { get; set; }
 
+    [JsonPropertyName("jobUrl")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? JobUrl { get; set; }
 
+    [JsonPropertyName("location")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? Location { get; set; }
 
+    [JsonPropertyName("workMode")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public WorkMode? WorkMode { get; set; }
 
+    [JsonPropertyName("salaryMin")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public int? SalaryMin { get; set; }
 
+    [JsonPropertyName("salaryMax")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public int? SalaryMax { get; set; }
 
     // DateOnly serializes as "YYYY-MM-DD" — DateTime would include a time component that breaks date inputs.
+    [JsonPropertyName("closedAt")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public DateOnly? ClosedAt { get; set; }
 
+    [JsonPropertyName("source")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? Source { get; set; }
 
     // Not extracted by Claude — the backend passes the input text through directly.
+    // No [JsonPropertyName]: intentionally excluded from the known-keys reflection check.
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? Description { get; set; }
 }

--- a/JobTrackerApi/Models/ParsedJobFields.cs
+++ b/JobTrackerApi/Models/ParsedJobFields.cs
@@ -1,0 +1,40 @@
+using System.Text.Json.Serialization;
+
+namespace JobTrackerApi.Models;
+
+/// <summary>Fields extracted from a raw job listing by the AI parser.</summary>
+public class ParsedJobFields
+{
+    // Null fields are omitted from the JSON response — frontend skips them in the merge step.
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Company { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Role { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? JobUrl { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Location { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public WorkMode? WorkMode { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? SalaryMin { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? SalaryMax { get; set; }
+
+    // DateOnly serializes as "YYYY-MM-DD" — DateTime would include a time component that breaks date inputs.
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public DateOnly? ClosedAt { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Source { get; set; }
+
+    // Not extracted by Claude — the backend passes the input text through directly.
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Description { get; set; }
+}

--- a/JobTrackerApi/Models/UserPreferencesDto.cs
+++ b/JobTrackerApi/Models/UserPreferencesDto.cs
@@ -2,13 +2,16 @@ using System.ComponentModel.DataAnnotations;
 
 namespace JobTrackerApi.Models;
 
-// Shape for GET and PUT /api/account/preferences.
-// VisibleColumns holds the keys of columns the user has chosen to show in the job table.
-// Fixed columns (company, role) are never included — they are always visible.
-// Valid keys: status, priority, appliedAt, closedAt, location, workMode, salary, interviewAt, jobUrl
-// Default (no saved preference): status, priority, appliedAt, closedAt
+/// <summary>Shape for GET and PUT /api/account/preferences.</summary>
 public class UserPreferencesDto
 {
+    // Keys of columns the user has chosen to show in the job table.
+    // Fixed columns (company, role) are never included — they are always visible.
+    // Valid keys: status, priority, appliedAt, closedAt, location, workMode, salary, interviewAt, jobUrl
+    // Default (no saved preference): status, priority, appliedAt, closedAt
     [Required]
     public List<string> VisibleColumns { get; set; } = [];
+
+    // Whether the AI auto-fill dialog appears before the Add Job sheet for AI users.
+    public bool AutoFillEnabled { get; set; } = true;
 }

--- a/JobTrackerApi/Program.cs
+++ b/JobTrackerApi/Program.cs
@@ -116,6 +116,13 @@ var adminEmail = builder.Configuration["Admin:Email"]
             : "Admin:Email is not configured. Set ADMIN_EMAIL environment variable."
     );
 
+var anthropicApiKey = builder.Configuration["Anthropic:ApiKey"]
+    ?? throw new InvalidOperationException(
+        builder.Environment.IsDevelopment()
+            ? "Anthropic:ApiKey is not configured. Add it to appsettings.Development.json."
+            : "Anthropic:ApiKey is not configured. Set ANTHROPIC_API_KEY environment variable."
+    );
+
 // Npgsql Entity Framework
 // https://www.npgsql.org/efcore/index.html?tabs=aspnet
 // No AddDbContextPool for safety and simplicity

--- a/JobTrackerApi/Program.cs
+++ b/JobTrackerApi/Program.cs
@@ -232,6 +232,15 @@ builder.Services.AddRateLimiter(options =>
         config.QueueLimit = 0;
         config.QueueProcessingOrder = System.Threading.RateLimiting.QueueProcessingOrder.OldestFirst;
     });
+
+    // Tight limit for parse — each request hits the Claude API; 2 per minute covers the paste-correction case
+    options.AddFixedWindowLimiter("parse", config =>
+    {
+        config.Window = TimeSpan.FromMinutes(1);
+        config.PermitLimit = 2;
+        config.QueueLimit = 0;
+        config.QueueProcessingOrder = System.Threading.RateLimiting.QueueProcessingOrder.OldestFirst;
+    });
 });
 
 // CORS only needed in dev — in production, Nginx proxies /api/* so frontend and backend share one origin

--- a/JobTrackerApi/Program.cs
+++ b/JobTrackerApi/Program.cs
@@ -152,6 +152,9 @@ if (builder.Environment.IsDevelopment())
 else
     builder.Services.AddHttpClient<IEmailService, ResendEmailService>();
 
+// AI parsing: extracts job fields from pasted listing text via Claude API
+builder.Services.AddScoped<IParsingService, ClaudeParsingService>();
+
 // Registers Identity's core services
 builder.Services.AddIdentityCore<ApplicationUser>()
     .AddRoles<IdentityRole>()

--- a/JobTrackerApi/Program.cs
+++ b/JobTrackerApi/Program.cs
@@ -233,7 +233,7 @@ builder.Services.AddRateLimiter(options =>
         config.QueueProcessingOrder = System.Threading.RateLimiting.QueueProcessingOrder.OldestFirst;
     });
 
-    // Tight limit for parse — each request hits the Claude API; 2 per minute covers the paste-correction case
+    // Tight limit for parse — each request hits the Claude API
     options.AddFixedWindowLimiter("parse", config =>
     {
         config.Window = TimeSpan.FromMinutes(1);

--- a/JobTrackerApi/Services/ClaudeParsingConfig.cs
+++ b/JobTrackerApi/Services/ClaudeParsingConfig.cs
@@ -3,9 +3,9 @@ namespace JobTrackerApi.Services;
 internal static class ClaudeParsingConfig
 {
     // claude-haiku-4-5-20251001: chosen 2026-05-23 — fastest/cheapest; extraction doesn't need reasoning depth; latency matters in form UX. Pinned ID (not alias) to prevent silent behavior changes.
-    public const string Model       = "claude-haiku-4-5-20251001";
-    public const int    MaxTokens   = 512;
-    public const float  Temperature = 0.0f;
+    public const string Model     = "claude-haiku-4-5-20251001";
+    public const int    MaxTokens = 512;
+    // Temperature not set — see plan Design Decisions
 
     public const string SystemPrompt = """
         You are a job listing parser. Extract fields from the raw listing text and return valid JSON only.

--- a/JobTrackerApi/Services/ClaudeParsingConfig.cs
+++ b/JobTrackerApi/Services/ClaudeParsingConfig.cs
@@ -1,0 +1,28 @@
+namespace JobTrackerApi.Services;
+
+internal static class ClaudeParsingConfig
+{
+    public const string Model       = "claude-haiku-4-5-20251001";
+    public const int    MaxTokens   = 512;
+    public const float  Temperature = 0.0f;
+
+    public const string SystemPrompt = """
+        You are a job listing parser. Extract the following fields from the raw
+        listing text provided by the user and return valid JSON only — no prose,
+        no markdown fences. Omit any field you cannot find (do not include it
+        with a null value).
+
+        Fields to extract:
+        - company (string): employer name
+        - role (string): job title
+        - jobUrl (string): application or listing URL
+        - location (string): city, region, or country
+        - workMode (string): one of "Remote", "Hybrid", or "OnSite"
+        - salaryMin (integer): minimum salary in NZD
+        - salaryMax (integer): maximum salary in NZD
+        - closedAt (string): closing date as YYYY-MM-DD, only if explicitly mentioned
+        - source (string): platform name inferred from URL or listing style (e.g. LinkedIn, Seek, Indeed)
+
+        Return only a JSON object. Example: {"company":"Acme","role":"Engineer","workMode":"Hybrid"}
+        """;
+}

--- a/JobTrackerApi/Services/ClaudeParsingConfig.cs
+++ b/JobTrackerApi/Services/ClaudeParsingConfig.cs
@@ -8,22 +8,44 @@ internal static class ClaudeParsingConfig
     public const float  Temperature = 0.0f;
 
     public const string SystemPrompt = """
-        You are a job listing parser. Extract the following fields from the raw
-        listing text provided by the user and return valid JSON only — no prose,
-        no markdown fences. Omit any field you cannot find (do not include it
-        with a null value).
+        You are a job listing parser. Extract fields from the raw listing text and return valid JSON only.
+
+        RULES:
+        - Return only a JSON object — no markdown fences, no prose before or after
+        - Omit fields you cannot find — do NOT include them as null
+        - Do NOT invent or guess values that are not present in the text
+        - workMode must be exactly "Remote", "Hybrid", or "OnSite" — omit if unclear
+        - salaryMin and salaryMax must be integers in NZD — omit if currency is unclear or not stated
+        - closedAt must be YYYY-MM-DD — omit if no closing date is explicitly stated
 
         Fields to extract:
         - company (string): employer name
         - role (string): job title
         - jobUrl (string): application or listing URL
         - location (string): city, region, or country
-        - workMode (string): one of "Remote", "Hybrid", or "OnSite"
+        - workMode (string): "Remote", "Hybrid", or "OnSite"
         - salaryMin (integer): minimum salary in NZD
         - salaryMax (integer): maximum salary in NZD
-        - closedAt (string): closing date as YYYY-MM-DD, only if explicitly mentioned
-        - source (string): platform name inferred from URL or listing style (e.g. LinkedIn, Seek, Indeed)
+        - closedAt (string): closing date as YYYY-MM-DD
+        - source (string): platform inferred from URL or listing style (e.g. "LinkedIn", "Seek", "Indeed")
 
-        Return only a JSON object. Example: {"company":"Acme","role":"Engineer","workMode":"Hybrid"}
+        Full extraction example:
+        {
+          "company": "Acme Corp",
+          "role": "Senior Software Engineer",
+          "jobUrl": "https://boards.greenhouse.io/acme/jobs/123",
+          "location": "Auckland",
+          "workMode": "Hybrid",
+          "salaryMin": 120000,
+          "salaryMax": 150000,
+          "closedAt": "2026-06-30",
+          "source": "Greenhouse"
+        }
+
+        Partial extraction (fields not found are omitted entirely):
+        {
+          "company": "Acme Corp",
+          "role": "Senior Software Engineer"
+        }
         """;
 }

--- a/JobTrackerApi/Services/ClaudeParsingConfig.cs
+++ b/JobTrackerApi/Services/ClaudeParsingConfig.cs
@@ -2,6 +2,7 @@ namespace JobTrackerApi.Services;
 
 internal static class ClaudeParsingConfig
 {
+    // claude-haiku-4-5-20251001: chosen 2026-05-23 — fastest/cheapest; extraction doesn't need reasoning depth; latency matters in form UX. Pinned ID (not alias) to prevent silent behavior changes.
     public const string Model       = "claude-haiku-4-5-20251001";
     public const int    MaxTokens   = 512;
     public const float  Temperature = 0.0f;

--- a/JobTrackerApi/Services/ClaudeParsingConfig.cs
+++ b/JobTrackerApi/Services/ClaudeParsingConfig.cs
@@ -11,23 +11,23 @@ internal static class ClaudeParsingConfig
         You are a job listing parser. Extract fields from the raw listing text and return valid JSON only.
 
         RULES:
-        - Return only a JSON object — no markdown fences, no prose before or after
-        - Omit fields you cannot find — do NOT include them as null
-        - Do NOT invent or guess values that are not present in the text
-        - workMode must be exactly "Remote", "Hybrid", or "OnSite" — omit if unclear
-        - salaryMin and salaryMax must be integers in NZD — omit if currency is unclear or not stated
-        - closedAt must be YYYY-MM-DD — omit if no closing date is explicitly stated
+        - Return only a JSON object. No markdown fences, no prose before or after.
+        - Omit fields you cannot find. Do NOT include them as null.
+        - Do NOT invent or guess values not present in the text.
+        - workMode must be exactly "Remote", "Hybrid", or "OnSite". Omit if unclear.
+        - salaryMin and salaryMax must be integers. Omit if no salary figure is present.
+        - closedAt must be YYYY-MM-DD. Omit if no closing date is explicitly stated.
 
         Fields to extract:
-        - company (string): employer name
-        - role (string): job title
-        - jobUrl (string): application or listing URL
-        - location (string): city, region, or country
-        - workMode (string): "Remote", "Hybrid", or "OnSite"
-        - salaryMin (integer): minimum salary in NZD
-        - salaryMax (integer): maximum salary in NZD
-        - closedAt (string): closing date as YYYY-MM-DD
-        - source (string): platform inferred from URL or listing style (e.g. "LinkedIn", "Seek", "Indeed")
+        - company: employer name
+        - role: job title
+        - jobUrl: application or listing URL
+        - location: city, region, or country where the role is based
+        - workMode: infer from phrasing. One value only: "Remote" for fully remote/WFH, "Hybrid" for flexible or partial office days, "OnSite" for fully office-based. Omit if you cannot determine which.
+        - salaryMin (integer): minimum salary as stated, or the exact amount if a fixed salary is given
+        - salaryMax (integer): maximum salary as stated. Omit if only a fixed salary is stated.
+        - closedAt: closing date as YYYY-MM-DD
+        - source: platform inferred from URL or listing style (e.g. "LinkedIn", "Seek", "Indeed")
 
         Full extraction example:
         {

--- a/JobTrackerApi/Services/ClaudeParsingService.cs
+++ b/JobTrackerApi/Services/ClaudeParsingService.cs
@@ -1,4 +1,5 @@
 using Anthropic;
+using Anthropic.Core;
 using Anthropic.Models.Messages;
 using System.Reflection;
 using System.Text.Json;
@@ -33,7 +34,7 @@ public class ClaudeParsingService : IParsingService
             ?? throw new InvalidOperationException("Anthropic:ApiKey is not configured.");
 
         // MaxRetries = 0: auto-retry adds 10–30 s of backoff with no benefit in a form UX — fail fast instead.
-        _client = new AnthropicClient(apiKey: apiKey, maxRetries: 0);
+        _client = new AnthropicClient(new ClientOptions { ApiKey = apiKey, MaxRetries = 0 });
         _logger = logger;
     }
 

--- a/JobTrackerApi/Services/ClaudeParsingService.cs
+++ b/JobTrackerApi/Services/ClaudeParsingService.cs
@@ -1,5 +1,5 @@
 using Anthropic.SDK;
-using Anthropic.SDK.Messages;
+using Anthropic.SDK.Messaging;
 using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -32,7 +32,8 @@ public class ClaudeParsingService : IParsingService
         var apiKey = configuration["Anthropic:ApiKey"]
             ?? throw new InvalidOperationException("Anthropic:ApiKey is not configured.");
 
-        _client = new AnthropicClient(apiKey);
+        // No retry policy, auto-retry adds 10–30s of backoff with no benefit in a form UX.
+        _client = new AnthropicClient(apiKey, new HttpClient());
         _logger = logger;
     }
 
@@ -46,7 +47,7 @@ public class ClaudeParsingService : IParsingService
             Messages = [new Message(RoleType.User, text)]
         });
 
-        var raw = response.Content.OfType<TextBlock>().FirstOrDefault()?.Text ?? string.Empty;
+        var raw = response.Content.OfType<TextContent>().FirstOrDefault()?.Text ?? string.Empty;
         var json = ExtractJson(raw);
         LogContractIssues(json);
 

--- a/JobTrackerApi/Services/ClaudeParsingService.cs
+++ b/JobTrackerApi/Services/ClaudeParsingService.cs
@@ -1,0 +1,29 @@
+using Anthropic;
+using Anthropic.Models.Messages;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using JobTrackerApi.Models;
+
+namespace JobTrackerApi.Services;
+
+/// <summary>Production implementation — parses job listings via the Claude API.</summary>
+public class ClaudeParsingService : IParsingService
+{
+    private readonly AnthropicClient _client;
+    private readonly ILogger<ClaudeParsingService> _logger;
+
+    public ClaudeParsingService(IConfiguration configuration, ILogger<ClaudeParsingService> logger)
+    {
+        var apiKey = configuration["Anthropic:ApiKey"]
+            ?? throw new InvalidOperationException("Anthropic:ApiKey is not configured.");
+
+        // MaxRetries = 0: auto-retry adds 10–30 s of backoff with no benefit in a form UX — fail fast instead.
+        _client = new AnthropicClient(apiKey: apiKey, maxRetries: 0);
+        _logger = logger;
+    }
+
+    public Task<ParsedJobFields> ParseListingAsync(string text)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/JobTrackerApi/Services/ClaudeParsingService.cs
+++ b/JobTrackerApi/Services/ClaudeParsingService.cs
@@ -49,7 +49,7 @@ public class ClaudeParsingService : IParsingService
 
         var raw  = response.Content.OfType<TextBlock>().FirstOrDefault()?.Text ?? string.Empty;
         var json = ExtractJson(raw);
-        // TODO: LogContractIssues(json);
+        LogContractIssues(json);
 
         try
         {
@@ -64,8 +64,8 @@ public class ClaudeParsingService : IParsingService
         }
     }
 
-    // Strips surrounding prose from Claude's response and returns the first { } block.
-    // Logs if text outside JSON was found or no JSON object exists at all.
+    // Claude may return prose around the JSON despite instructions — extract the first { } block.
+    // Falls back to "{}" so deserialization always yields a safe empty result rather than throwing.
     private string ExtractJson(string raw)
     {
         var trimmed = raw.Trim();
@@ -84,5 +84,31 @@ public class ClaudeParsingService : IParsingService
             _logger.LogWarning("Parse response contains text outside JSON. Raw: {Raw}", raw);
 
         return json;
+    }
+
+    // Logs contract violations to tune the system prompt over time — not surfaced to the user.
+    // JsonException is swallowed: if JSON is malformed, ParseListingAsync logs and handles it.
+    private void LogContractIssues(string json)
+    {
+        try
+        {
+            using var doc   = JsonDocument.Parse(json);
+            var       props = doc.RootElement.EnumerateObject().ToList();
+
+            if (props.Count == 0)
+            {
+                _logger.LogWarning("Parse response is an empty object.");
+                return;
+            }
+
+            foreach (var prop in props)
+            {
+                if (!_knownKeys.Contains(prop.Name))
+                    _logger.LogWarning("Unexpected key in parse response: {Key}", prop.Name);
+                else if (prop.Value.ValueKind == JsonValueKind.Null)
+                    _logger.LogWarning("Parsed field is null: {Field}", prop.Name);
+            }
+        }
+        catch (JsonException) { }
     }
 }

--- a/JobTrackerApi/Services/ClaudeParsingService.cs
+++ b/JobTrackerApi/Services/ClaudeParsingService.cs
@@ -1,6 +1,5 @@
-using Anthropic;
-using Anthropic.Core;
-using Anthropic.Models.Messages;
+using Anthropic.SDK;
+using Anthropic.SDK.Messages;
 using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -33,19 +32,18 @@ public class ClaudeParsingService : IParsingService
         var apiKey = configuration["Anthropic:ApiKey"]
             ?? throw new InvalidOperationException("Anthropic:ApiKey is not configured.");
 
-        // MaxRetries = 0: auto-retry adds 10–30 s of backoff with no benefit in a form UX — fail fast instead.
-        _client = new AnthropicClient(new ClientOptions { ApiKey = apiKey, MaxRetries = 0 });
+        _client = new AnthropicClient(apiKey);
         _logger = logger;
     }
 
     public async Task<ParsedJobFields> ParseListingAsync(string text)
     {
-        var response = await _client.Messages.Create(new MessageCreateParams
+        var response = await _client.Messages.GetClaudeMessageAsync(new MessageParameters
         {
             Model = ClaudeParsingConfig.Model,
             MaxTokens = ClaudeParsingConfig.MaxTokens,
-            System = ClaudeParsingConfig.SystemPrompt,
-            Messages = [new MessageParam { Role = Role.User, Content = text }]
+            System = [new SystemMessage(ClaudeParsingConfig.SystemPrompt)],
+            Messages = [new Message(RoleType.User, text)]
         });
 
         var raw = response.Content.OfType<TextBlock>().FirstOrDefault()?.Text ?? string.Empty;

--- a/JobTrackerApi/Services/ClaudeParsingService.cs
+++ b/JobTrackerApi/Services/ClaudeParsingService.cs
@@ -10,14 +10,15 @@ namespace JobTrackerApi.Services;
 /// <summary>Production implementation — parses job listings via the Claude API.</summary>
 public class ClaudeParsingService : IParsingService
 {
-    // Derived from [JsonPropertyName] on ParsedJobFields via reflection — single source of truth; computed once at class load.
+    // Derived from [JsonPropertyName] on ParsedJobFields via reflection
+    // Single source of truth, computed once at class load.
     private static readonly HashSet<string> _knownKeys = typeof(ParsedJobFields)
         .GetProperties()
         .Select(p => p.GetCustomAttribute<JsonPropertyNameAttribute>()?.Name)
         .Where(name => name != null)
         .ToHashSet()!;
 
-    // JsonStringEnumConverter: required for Claude's string enum values (e.g. "Remote" → WorkMode).
+    // JsonStringEnumConverter: required for Claude's string enum values.
     private static readonly JsonSerializerOptions _jsonOptions = new()
     {
         Converters = { new JsonStringEnumConverter() }
@@ -36,8 +37,49 @@ public class ClaudeParsingService : IParsingService
         _logger = logger;
     }
 
-    public Task<ParsedJobFields> ParseListingAsync(string text)
+    public async Task<ParsedJobFields> ParseListingAsync(string text)
     {
-        throw new NotImplementedException();
+        var response = await _client.Messages.Create(new MessageCreateParams
+        {
+            Model     = ClaudeParsingConfig.Model,
+            MaxTokens = ClaudeParsingConfig.MaxTokens,
+            System    = ClaudeParsingConfig.SystemPrompt,
+            Messages  = [new MessageParam { Role = Role.User, Content = text }]
+        });
+
+        var raw  = response.Content.OfType<TextBlock>().FirstOrDefault()?.Text ?? string.Empty;
+        var json = ExtractJson(raw);
+        // TODO: LogContractIssues(json);
+
+        try
+        {
+            var result = JsonSerializer.Deserialize<ParsedJobFields>(json, _jsonOptions) ?? new ParsedJobFields();
+            result.Description = text;
+            return result;
+        }
+        catch (JsonException ex)
+        {
+            _logger.LogWarning(ex, "Failed to deserialize parse response. Raw: {Raw}", raw);
+            return new ParsedJobFields { Description = text };
+        }
+    }
+
+    private string ExtractJson(string raw)
+    {
+        var trimmed = raw.Trim();
+        var start   = trimmed.IndexOf('{');
+        var end     = trimmed.LastIndexOf('}');
+
+        if (start == -1 || end == -1 || end < start)
+            // TODO: log warning — no JSON object found
+            return "{}";
+
+        var json = trimmed[start..(end + 1)];
+
+        if (start > 0 || end < trimmed.Length - 1)
+            // TODO: log warning — surrounding text present
+            ;
+
+        return json;
     }
 }

--- a/JobTrackerApi/Services/ClaudeParsingService.cs
+++ b/JobTrackerApi/Services/ClaudeParsingService.cs
@@ -41,13 +41,13 @@ public class ClaudeParsingService : IParsingService
     {
         var response = await _client.Messages.Create(new MessageCreateParams
         {
-            Model     = ClaudeParsingConfig.Model,
+            Model = ClaudeParsingConfig.Model,
             MaxTokens = ClaudeParsingConfig.MaxTokens,
-            System    = ClaudeParsingConfig.SystemPrompt,
-            Messages  = [new MessageParam { Role = Role.User, Content = text }]
+            System = ClaudeParsingConfig.SystemPrompt,
+            Messages = [new MessageParam { Role = Role.User, Content = text }]
         });
 
-        var raw  = response.Content.OfType<TextBlock>().FirstOrDefault()?.Text ?? string.Empty;
+        var raw = response.Content.OfType<TextBlock>().FirstOrDefault()?.Text ?? string.Empty;
         var json = ExtractJson(raw);
         LogContractIssues(json);
 
@@ -69,8 +69,8 @@ public class ClaudeParsingService : IParsingService
     private string ExtractJson(string raw)
     {
         var trimmed = raw.Trim();
-        var start   = trimmed.IndexOf('{');
-        var end     = trimmed.LastIndexOf('}');
+        var start = trimmed.IndexOf('{');
+        var end = trimmed.LastIndexOf('}');
 
         if (start == -1 || end == -1 || end < start)
         {
@@ -92,8 +92,8 @@ public class ClaudeParsingService : IParsingService
     {
         try
         {
-            using var doc   = JsonDocument.Parse(json);
-            var       props = doc.RootElement.EnumerateObject().ToList();
+            using var doc = JsonDocument.Parse(json);
+            var props = doc.RootElement.EnumerateObject().ToList();
 
             if (props.Count == 0)
             {

--- a/JobTrackerApi/Services/ClaudeParsingService.cs
+++ b/JobTrackerApi/Services/ClaudeParsingService.cs
@@ -1,5 +1,6 @@
 using Anthropic;
 using Anthropic.Models.Messages;
+using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using JobTrackerApi.Models;
@@ -9,6 +10,19 @@ namespace JobTrackerApi.Services;
 /// <summary>Production implementation — parses job listings via the Claude API.</summary>
 public class ClaudeParsingService : IParsingService
 {
+    // Derived from [JsonPropertyName] on ParsedJobFields via reflection — single source of truth; computed once at class load.
+    private static readonly HashSet<string> _knownKeys = typeof(ParsedJobFields)
+        .GetProperties()
+        .Select(p => p.GetCustomAttribute<JsonPropertyNameAttribute>()?.Name)
+        .Where(name => name != null)
+        .ToHashSet()!;
+
+    // JsonStringEnumConverter: required for Claude's string enum values (e.g. "Remote" → WorkMode).
+    private static readonly JsonSerializerOptions _jsonOptions = new()
+    {
+        Converters = { new JsonStringEnumConverter() }
+    };
+
     private readonly AnthropicClient _client;
     private readonly ILogger<ClaudeParsingService> _logger;
 

--- a/JobTrackerApi/Services/ClaudeParsingService.cs
+++ b/JobTrackerApi/Services/ClaudeParsingService.cs
@@ -87,7 +87,6 @@ public class ClaudeParsingService : IParsingService
     }
 
     // Logs contract violations to tune the system prompt over time — not surfaced to the user.
-    // JsonException is swallowed: if JSON is malformed, ParseListingAsync logs and handles it.
     private void LogContractIssues(string json)
     {
         try
@@ -109,6 +108,7 @@ public class ClaudeParsingService : IParsingService
                     _logger.LogWarning("Parsed field is null: {Field}", prop.Name);
             }
         }
+        // ParseListingAsync logs and handles it
         catch (JsonException) { }
     }
 }

--- a/JobTrackerApi/Services/ClaudeParsingService.cs
+++ b/JobTrackerApi/Services/ClaudeParsingService.cs
@@ -64,6 +64,8 @@ public class ClaudeParsingService : IParsingService
         }
     }
 
+    // Strips surrounding prose from Claude's response and returns the first { } block.
+    // Logs if text outside JSON was found or no JSON object exists at all.
     private string ExtractJson(string raw)
     {
         var trimmed = raw.Trim();
@@ -71,14 +73,15 @@ public class ClaudeParsingService : IParsingService
         var end     = trimmed.LastIndexOf('}');
 
         if (start == -1 || end == -1 || end < start)
-            // TODO: log warning — no JSON object found
+        {
+            _logger.LogWarning("Parse response contains no JSON object. Raw: {Raw}", raw);
             return "{}";
+        }
 
         var json = trimmed[start..(end + 1)];
 
         if (start > 0 || end < trimmed.Length - 1)
-            // TODO: log warning — surrounding text present
-            ;
+            _logger.LogWarning("Parse response contains text outside JSON. Raw: {Raw}", raw);
 
         return json;
     }

--- a/JobTrackerApi/Services/IParsingService.cs
+++ b/JobTrackerApi/Services/IParsingService.cs
@@ -1,3 +1,5 @@
+using JobTrackerApi.Models;
+
 namespace JobTrackerApi.Services;
 
 /// <summary>Abstraction for parsing raw job listing text into structured fields.</summary>

--- a/JobTrackerApi/Services/IParsingService.cs
+++ b/JobTrackerApi/Services/IParsingService.cs
@@ -1,0 +1,8 @@
+namespace JobTrackerApi.Services;
+
+/// <summary>Abstraction for parsing raw job listing text into structured fields.</summary>
+public interface IParsingService
+{
+    /// <summary>Extracts job fields from raw listing text using an AI model.</summary>
+    Task<ParsedJobFields> ParseListingAsync(string text);
+}

--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -35,6 +35,7 @@ services:
       - Email__FromAddress=${EMAIL_FROM_ADDRESS}
       - Resend__ApiKey=${RESEND_API_KEY}
       - Admin__Email=${ADMIN_EMAIL}
+      - Anthropic__ApiKey=${ANTHROPIC_API_KEY}
       - AWS_REGION=ap-southeast-2  # AWS SDK reads this automatically for S3 + IAM
       
       # Allowlist for frontend base URL used in email links (confirm, reset password).

--- a/docs/deployment-setup.md
+++ b/docs/deployment-setup.md
@@ -42,6 +42,7 @@ Add these in: **repo → Settings → Secrets and variables → Actions → New 
 | `DEMO_RESET_KEY` | Long random string — authorizes `POST /api/auth/demo/reset` called by the nightly cron |
 | `EMAIL_FROM_ADDRESS` | Sender address for transactional emails — `noreply@jobtracker.nagarenegishi.com` |
 | `RESEND_API_KEY` | Resend API key with Sending access permission only |
+| `ANTHROPIC_API_KEY` | Anthropic API key — used by `ClaudeParsingService` for auto-fill job parsing |
 
 Generate random secrets with:
 ```

--- a/docs/plans/ai-access-admin.md
+++ b/docs/plans/ai-access-admin.md
@@ -67,7 +67,7 @@ Response: 200 on success, 404 if user not found, 400 if toggling own access.
 | 6 | Add `AdminController` — `GET /api/admin/users` + `PATCH /api/admin/users/{userId}/ai-access` | done |
 | 7 | Frontend: `getRoles()`/`hasRole()` in `auth.ts`; `AdminRoute` component; `/admin` route in `App.tsx`; `adminService.ts`; TanStack Query hooks; `AdminPage` with user table and `IsAiUser` toggle | done |
 | 8 | Unit tests — `AdminControllerTests.cs` (6 tests: `GetUsers`, `UpdateAiAccess`); 3 `ConfirmEmail` admin promotion tests added to `AuthControllerTests.cs` | done |
-| 9 | Production config — add `Admin__Email: ${ADMIN_EMAIL}` to backend `environment` in `compose.prod.yml`; add `ADMIN_EMAIL=admin@example.com` placeholder to `.env.example`; add `export ADMIN_EMAIL="${{ secrets.ADMIN_EMAIL }}"` to deploy job SSH session in `.github/workflows/deploy.yml`; add `ADMIN_EMAIL` as a GitHub Actions secret | merged, unverified |
+| 9 | Production config — add `Admin__Email: ${ADMIN_EMAIL}` to backend `environment` in `compose.prod.yml`; add `ADMIN_EMAIL=admin@example.com` placeholder to `.env.example`; add `export ADMIN_EMAIL="${{ secrets.ADMIN_EMAIL }}"` to deploy job SSH session in `.github/workflows/deploy.yml`; add `ADMIN_EMAIL` as a GitHub Actions secret | done |
 
 ---
 

--- a/docs/plans/auto-fill-parsing.md
+++ b/docs/plans/auto-fill-parsing.md
@@ -114,7 +114,7 @@ Key decisions:
 | 7 | Add `autoFillEnabled: boolean` to frontend `Preferences` type in `preferencesService.ts` | — |
 | 8 | Add AI-only `autoFillEnabled` toggle to `SettingsPage` | — |
 | 9 | Revert collapsible section from `JobCreateSheet`; add optional `initialData?: Partial<FormState>` prop | — |
-| 10 | New `ParseListingDialog` — textarea, "Fill fields" (calls `/api/jobs/parse`, loading + error state, passes result to sheet), "Fill manually" (opens sheet empty), Cancel | — |
+| 10 | New `ParseListingDialog` — textarea, "Fill fields" (calls `/api/jobs/parse`, loading + error state, passes result to sheet), "Fill manually" (opens sheet empty), Cancel | `parseService.ts` done; open decision: export `FormState` from `JobCreateSheet.tsx` (Option A, simpler) or move to a shared types file (Option B) — decide before building dialog |
 | 11 | Wire "Add job" in `JobPage` — check `hasRole("AiUser")` + `autoFillEnabled` → dialog or sheet | — |
 
 ---

--- a/docs/plans/auto-fill-parsing.md
+++ b/docs/plans/auto-fill-parsing.md
@@ -13,7 +13,7 @@ A "Parse" button in the Add Job sheet. User pastes raw listing text → backend 
 | `IParsingService` / `ClaudeParsingService` in `Services/` | Follows existing service abstraction pattern (`IStorageService`, `IEmailService`); mockable in tests |
 | `claude-haiku-4-5` model | Fastest and cheapest; extraction task doesn't need reasoning depth; latency matters in a form UX |
 | Structured JSON prompt (system prompt defines schema) | More reliable field extraction than free-text; Claude returns valid JSON consistently with a tight schema |
-| `POST /api/jobs/parse-listing` returns partial `JobDTO` shape | Frontend already knows the `JobDTO` shape; no new types needed |
+| `POST /api/jobs/parse` returns partial `JobDTO` shape | Frontend already knows the `JobDTO` shape; no new types needed |
 | Merge strategy: only fill empty fields | Prevents overwriting data the user typed manually before hitting Parse |
 | Collapsible textarea in Add Job sheet | Keeps the form clean for users who don't need parsing; expands on demand |
 | Fail-fast on missing `Anthropic:ApiKey` | Matches existing JWT config validation pattern in `Program.cs` |
@@ -24,6 +24,9 @@ A "Parse" button in the Add Job sheet. User pastes raw listing text → backend 
 | `Temperature` not set in `MessageCreateParams` | `Temperature` is `[Obsolete]` in SDK v12.x — models after Opus 4.6 reject non-1.0 values with 400. Haiku 4.5 predates Opus 4.6 by version number but the risk isn't worth taking. If the model changes, revisit. Prompt design (explicit rules + examples) enforces deterministic extraction without it. |
 | `[JsonPropertyName("company")]` attributes on `ParsedJobFields`; no `PropertyNameCaseInsensitive` | Explicit contract — JSON key mapping is visible in the model. Wrong casing from Claude is treated as a contract violation: logged as unexpected key, value dropped. Keeps the schema strict and predictable. |
 | Known keys for logging derived from `[JsonPropertyName]` attributes via reflection (`static readonly HashSet<string>`) | Single source of truth — model is the contract. Adding a field to `ParsedJobFields` automatically includes it in the known keys set. Hardcoded list risks silently going stale. Computed once at class load (`static readonly`) so reflection cost is paid once. |
+| `IValidatableObject` for HTML detection in `ParseListingRequest`; not `[RegularExpression]` | `[RegularExpression]` validates that a value matches a pattern — inverting it (must NOT contain HTML) requires a confusing negative lookahead. `IValidatableObject` keeps the rule readable and matches `JobDTO`'s cross-field validation pattern. |
+| HTML validation error is `"Invalid request."` — generic, no detail | Only a crafted API request triggers this rule — a real user pasting into a textarea never produces HTML in the body. A descriptive message would tell the attacker exactly what to remove. |
+| No `IsDemo()` check on the parse endpoint | `[Authorize(Policy = "AiEnabled")]` already blocks the demo user — demo account is never granted `"AiUser"` role. An explicit `IsDemo()` guard would be redundant and misleading (implies it's the actual guard when it isn't). |
 
 ---
 
@@ -31,7 +34,7 @@ A "Parse" button in the Add Job sheet. User pastes raw listing text → backend 
 
 ### Request
 ```
-POST /api/jobs/parse-listing
+POST /api/jobs/parse
 Authorization: Bearer <token>
 Content-Type: application/json
 
@@ -100,7 +103,7 @@ Key decisions:
 |---|---|---|
 | 1 | Add `Anthropic:ApiKey` to config + fail-fast validation in `Program.cs` | ✅ |
 | 2 | Add `ParsedJobFields` model + `IParsingService` + `ClaudeParsingService` stub + `ClaudeParsingConfig` | ✅ config; impl pending |
-| 3 | Add `ParseListingRequest` DTO + input validation + `POST /api/jobs/parse-listing` with `[Authorize(Policy = "AiEnabled")]` + `[EnableRateLimiting("parse")]` in `JobsController` | — |
+| 3 | Add `ParseListingRequest` DTO + input validation + `POST /api/jobs/parse` with `[Authorize(Policy = "AiEnabled")]` + `[EnableRateLimiting("parse")]` in `JobsController` | — |
 | 4 | Register `ClaudeParsingService` + add `"parse"` rate limit policy (2 per minute per IP) in `Program.cs` | — |
 | 5 | Add collapsible textarea + "Parse" button to Add Job sheet | — |
 | 6 | Call endpoint on Parse click; show loading and error state | — |

--- a/docs/plans/auto-fill-parsing.md
+++ b/docs/plans/auto-fill-parsing.md
@@ -76,9 +76,16 @@ Fields not found are omitted (not null) — frontend skips them in the merge ste
 
 ## Prompt Design
 
-System prompt instructs Claude to extract these fields from raw listing text: `company`, `role`, `jobUrl`, `location`, `workMode` (`Remote` / `Hybrid` / `OnSite`), `salaryMin`, `salaryMax` (integers, NZD assumed), `closedAt` (ISO date if closing date mentioned), `source` (infer from URL pattern or text style — e.g. LinkedIn, Seek, Indeed). Return valid JSON only, no prose. Omit fields not found.
+System prompt uses a RULES section + Fields section + two examples (full and partial extraction).
 
-`description` is not extracted by Claude — the backend passes through the input text directly.
+Key decisions:
+- workMode: inferred from phrasing, not keyword matched. One value only; omit if unclear.
+- salaryMin/salaryMax: integers, no currency assumption. Fixed salary → salaryMin only; salaryMax omitted.
+- location: "where the role is based" — avoids matching eligibility or visa text.
+- Fields not found are omitted (not null) — matches `[JsonIgnore(WhenWritingNull)]` on the model.
+- Full extraction example included so Claude knows the exact expected shape.
+
+`description` is not extracted by Claude — the backend passes the input text through directly.
 
 ---
 

--- a/docs/plans/auto-fill-parsing.md
+++ b/docs/plans/auto-fill-parsing.md
@@ -22,6 +22,8 @@ A "Parse" button in the Add Job sheet. User pastes raw listing text → backend 
 | 2 requests per minute per IP via `[EnableRateLimiting("parse")]` | Each call costs money; 2 covers the paste-correction case (wrong paste → fix → retry); reuses existing rate limiter pattern |
 | `MaxRetries = 0` on `AnthropicClient` | Auto-retry on traffic failures adds 10–30 s of backoff with no benefit — fail fast and surface the error to the user |
 | `Temperature` not set in `MessageCreateParams` | `Temperature` is `[Obsolete]` in SDK v12.x — models after Opus 4.6 reject non-1.0 values with 400. Haiku 4.5 predates Opus 4.6 by version number but the risk isn't worth taking. If the model changes, revisit. Prompt design (explicit rules + examples) enforces deterministic extraction without it. |
+| `[JsonPropertyName("company")]` attributes on `ParsedJobFields`; no `PropertyNameCaseInsensitive` | Explicit contract — JSON key mapping is visible in the model. Wrong casing from Claude is treated as a contract violation: logged as unexpected key, value dropped. Keeps the schema strict and predictable. |
+| Known keys for logging derived from `[JsonPropertyName]` attributes via reflection (`static readonly HashSet<string>`) | Single source of truth — model is the contract. Adding a field to `ParsedJobFields` automatically includes it in the known keys set. Hardcoded list risks silently going stale. Computed once at class load (`static readonly`) so reflection cost is paid once. |
 
 ---
 

--- a/docs/plans/auto-fill-parsing.md
+++ b/docs/plans/auto-fill-parsing.md
@@ -21,6 +21,7 @@ A "Parse" button in the Add Job sheet. User pastes raw listing text → backend 
 | `[Authorize(Policy = "AiEnabled")]` on the endpoint | Restricts parsing to users with `"AiUser"` role — policy defined in `ai-access-admin` plan |
 | 2 requests per minute per IP via `[EnableRateLimiting("parse")]` | Each call costs money; 2 covers the paste-correction case (wrong paste → fix → retry); reuses existing rate limiter pattern |
 | `MaxRetries = 0` on `AnthropicClient` | Auto-retry on traffic failures adds 10–30 s of backoff with no benefit — fail fast and surface the error to the user |
+| `Temperature` not set in `MessageCreateParams` | `Temperature` is `[Obsolete]` in SDK v12.x — models after Opus 4.6 reject non-1.0 values with 400. Haiku 4.5 predates Opus 4.6 by version number but the risk isn't worth taking. If the model changes, revisit. Prompt design (explicit rules + examples) enforces deterministic extraction without it. |
 
 ---
 
@@ -96,7 +97,7 @@ Key decisions:
 | # | Item | Status |
 |---|---|---|
 | 1 | Add `Anthropic:ApiKey` to config + fail-fast validation in `Program.cs` | ✅ |
-| 2 | Add `ParsedJobFields` model + `IParsingService` + `ClaudeParsingService` stub in `Services/` (`ParseListingAsync` throws `NotImplementedException` — prompt + implementation pending) | ✅ stub |
+| 2 | Add `ParsedJobFields` model + `IParsingService` + `ClaudeParsingService` stub + `ClaudeParsingConfig` | ✅ config; impl pending |
 | 3 | Add `ParseListingRequest` DTO + input validation + `POST /api/jobs/parse-listing` with `[Authorize(Policy = "AiEnabled")]` + `[EnableRateLimiting("parse")]` in `JobsController` | — |
 | 4 | Register `ClaudeParsingService` + add `"parse"` rate limit policy (2 per minute per IP) in `Program.cs` | — |
 | 5 | Add collapsible textarea + "Parse" button to Add Job sheet | — |

--- a/docs/plans/auto-fill-parsing.md
+++ b/docs/plans/auto-fill-parsing.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-A "Parse" button in the Add Job sheet. User pastes raw listing text → backend sends it to Claude API → returns a partial `JobDTO` → form fields pre-filled. User reviews and saves. Phase 1 only (copy-paste). Phase 2 (URL fetch) deferred.
+AI users get a `ParseListingDialog` before the Add Job sheet. User pastes raw listing text → backend sends it to Claude API → returns a partial `JobDTO` → create sheet opens pre-filled. User reviews and saves. Non-AI users go straight to the create sheet. AI users can opt out via a settings toggle. Phase 1 only (copy-paste). Phase 2 (URL fetch) deferred.
 
 ---
 
@@ -14,8 +14,12 @@ A "Parse" button in the Add Job sheet. User pastes raw listing text → backend 
 | `claude-haiku-4-5` model | Fastest and cheapest; extraction task doesn't need reasoning depth; latency matters in a form UX |
 | Structured JSON prompt (system prompt defines schema) | More reliable field extraction than free-text; Claude returns valid JSON consistently with a tight schema |
 | `POST /api/jobs/parse` returns partial `JobDTO` shape | Frontend already knows the `JobDTO` shape; no new types needed |
-| Merge strategy: only fill empty fields | Prevents overwriting data the user typed manually before hitting Parse |
-| Collapsible textarea in Add Job sheet | Keeps the form clean for users who don't need parsing; expands on demand |
+| `ParseListingDialog` as a separate entry point before `JobCreateSheet` | Enforces auto-fill → adjust flow; avoids mid-form mode switching and the confusion of switching from manual to auto partway through |
+| `JobCreateSheet` accepts optional `initialData` prop | Dialog passes parsed fields to the sheet; sheet stays self-contained and reusable for the manual flow |
+| No retry in `ParseListingDialog` | Same text → same result (deterministic extraction); wrong text → re-paste. Retry UI implies non-determinism that doesn't exist |
+| `autoFillEnabled` stored in existing `Preferences` JSON blob on `ApplicationUser` | No migration needed — existing string column already holds JSON; adding a field to `UserPreferencesDto` with `= true` default covers users who have never saved this preference |
+| `autoFillEnabled` defaults to `true` for AI users | Dialog-first is the intended flow; users who prefer manual can opt out in settings |
+| Toggle only shown in Settings for AI users | Non-AI users never see the dialog, so the toggle is irrelevant to them |
 | Fail-fast on missing `Anthropic:ApiKey` | Matches existing JWT config validation pattern in `Program.cs` |
 | Block demo user (403) | Prevents API cost from demo accounts; same pattern as `DocumentsController` |
 | `[Authorize(Policy = "AiEnabled")]` on the endpoint | Restricts parsing to users with `"AiUser"` role — policy defined in `ai-access-admin` plan |
@@ -105,10 +109,13 @@ Key decisions:
 | 2 | Add `ParsedJobFields` model + `IParsingService` + `ClaudeParsingService` (full impl) + `ClaudeParsingConfig` | ✅ |
 | 3 | Add `ParseListingRequest` DTO + input validation + `POST /api/jobs/parse` with `[Authorize(Policy = "AiEnabled")]` + `[EnableRateLimiting("parse")]` in `JobsController` | ✅ |
 | 4 | Register `ClaudeParsingService` + add `"parse"` rate limit policy (2 per minute per IP) in `Program.cs` | ✅ |
-| 5 | Add controller tests for `POST /api/jobs/parse` — mock `IParsingService`; cover: 200 with partial result, 400 empty input, 400 over 8000 chars, 400 HTML input, 401 unauthenticated, 403 missing `AiEnabled` policy | — |
-| 6 | Add collapsible textarea + "Parse" button to Add Job sheet | — |
-| 7 | Call endpoint on Parse click; show loading and error state | — |
-| 8 | Merge response into form state (empty fields only) | — |
+| 5 | Add controller tests for `POST /api/jobs/parse` — mock `IParsingService`; cover: 200 with partial result, 400 empty input, 400 over 8000 chars, 400 HTML input | ✅ |
+| 6 | Add `bool AutoFillEnabled { get; set; } = true` to `UserPreferencesDto` | — |
+| 7 | Add `autoFillEnabled: boolean` to frontend `Preferences` type in `preferencesService.ts` | — |
+| 8 | Add AI-only `autoFillEnabled` toggle to `SettingsPage` | — |
+| 9 | Revert collapsible section from `JobCreateSheet`; add optional `initialData?: Partial<FormState>` prop | — |
+| 10 | New `ParseListingDialog` — textarea, "Fill fields" (calls `/api/jobs/parse`, loading + error state, passes result to sheet), "Fill manually" (opens sheet empty), Cancel | — |
+| 11 | Wire "Add job" in `JobPage` — check `hasRole("AiUser")` + `autoFillEnabled` → dialog or sheet | — |
 
 ---
 

--- a/docs/plans/auto-fill-parsing.md
+++ b/docs/plans/auto-fill-parsing.md
@@ -129,21 +129,16 @@ Strip surrounding text and attempt JSON parse regardless — log the anomaly but
 
 ## Dependencies
 
-### Anthropic
-Official C# NuGet package from Anthropic. Installed: v12.23.0. Install: `dotnet add package Anthropic`.
+### Anthropic.SDK (tghamm)
+Community C# NuGet package. Install: `dotnet add package Anthropic.SDK`.
 
-**SDK API shape — v12.23.0 — PARTIALLY WRONG. Build errors found 2026-05-24:**
+**Switched from official `Anthropic` package (v12.23.0).** Official package is auto-generated from the API spec (Stainless) — not human-maintained C#. Auto-generated code does not follow C# conventions: response types use a discriminated union with no ergonomic helpers; `OfType<TextBlock>()` silently returns empty (CA2021). "Actively maintained" means API-spec-synchronized only, not C# experience maintained. tghamm uses standard C# inheritance — idiomatic, documented, maintainable. Extra dependency is the correct tradeoff when the official package harms maintainability.
 
-| Line | Error | Detail |
-|---|---|---|
-| 36 | `CS1739` | `AnthropicClient` has no named parameter `apiKey`. `new AnthropicClient(apiKey: apiKey, maxRetries: 0)` does not compile. Correct constructor signature is unknown — must be derived from local NuGet cache inspection, not official docs. Related to `ClientOptions.cs` in the SDK. |
-| 50 | `CA2021` | `ContentBlock` and `TextBlock` are incompatible types; `response.Content.OfType<TextBlock>()` always returns empty. The plan's documented response-reading API is wrong. |
-
-Known-good (not implicated by build errors):
-- Send: `await client.Messages.Create(new MessageCreateParams { ... })`
-- Role enum: `Role.User` (namespace `Anthropic.Models.Messages`)
-
-Chosen over the community `Anthropic.SDK` (tghamm): only basic message creation is needed here — the official package covers it, avoids a third-party maintenance dependency, and includes `IChatClient` integration for future provider abstraction.
+**SDK API shape — verified from tghamm README 2026-05-24:**
+- Client: `new AnthropicClient(apiKey)` — plain HttpClient, no retries by default
+- Send: `await client.Messages.GetClaudeMessageAsync(new MessageParameters { ... })`
+- Role: `RoleType.User`; Message param: `new Message(RoleType.User, text)`
+- Read response: `response.Content.OfType<TextContent>().First().Text` ✅
 
 ---
 

--- a/docs/plans/auto-fill-parsing.md
+++ b/docs/plans/auto-fill-parsing.md
@@ -20,6 +20,7 @@ A "Parse" button in the Add Job sheet. User pastes raw listing text → backend 
 | Block demo user (403) | Prevents API cost from demo accounts; same pattern as `DocumentsController` |
 | `[Authorize(Policy = "AiEnabled")]` on the endpoint | Restricts parsing to users with `"AiUser"` role — policy defined in `ai-access-admin` plan |
 | 2 requests per minute per IP via `[EnableRateLimiting("parse")]` | Each call costs money; 2 covers the paste-correction case (wrong paste → fix → retry); reuses existing rate limiter pattern |
+| `MaxRetries = 0` on `AnthropicClient` | Auto-retry on traffic failures adds 10–30 s of backoff with no benefit — fail fast and surface the error to the user |
 
 ---
 
@@ -114,8 +115,8 @@ Strip surrounding text and attempt JSON parse regardless — log the anomaly but
 
 ## Dependencies
 
-### Anthropic.SDK
-Official C# NuGet package for the Claude API.
+### Anthropic
+Official C# NuGet package from Anthropic (v10+). Install: `dotnet add package Anthropic`.
 
 ---
 

--- a/docs/plans/auto-fill-parsing.md
+++ b/docs/plans/auto-fill-parsing.md
@@ -110,12 +110,12 @@ Key decisions:
 | 3 | Add `ParseListingRequest` DTO + input validation + `POST /api/jobs/parse` with `[Authorize(Policy = "AiEnabled")]` + `[EnableRateLimiting("parse")]` in `JobsController` | ✅ |
 | 4 | Register `ClaudeParsingService` + add `"parse"` rate limit policy (2 per minute per IP) in `Program.cs` | ✅ |
 | 5 | Add controller tests for `POST /api/jobs/parse` — mock `IParsingService`; cover: 200 with partial result, 400 empty input, 400 over 8000 chars, 400 HTML input | ✅ |
-| 6 | Add `bool AutoFillEnabled { get; set; } = true` to `UserPreferencesDto` | — |
-| 7 | Add `autoFillEnabled: boolean` to frontend `Preferences` type in `preferencesService.ts` | — |
-| 8 | Add AI-only `autoFillEnabled` toggle to `SettingsPage` | — |
-| 9 | Revert collapsible section from `JobCreateSheet`; add optional `initialData?: Partial<FormState>` prop | — |
-| 10 | New `ParseListingDialog` — textarea, "Fill fields" (calls `/api/jobs/parse`, loading + error state, passes result to sheet), "Fill manually" (opens sheet empty), Cancel | `parseService.ts` done; open decision: export `FormState` from `JobCreateSheet.tsx` (Option A, simpler) or move to a shared types file (Option B) — decide before building dialog |
-| 11 | Wire "Add job" in `JobPage` — check `hasRole("AiUser")` + `autoFillEnabled` → dialog or sheet | — |
+| 6 | Add `bool AutoFillEnabled { get; set; } = true` to `UserPreferencesDto` | ✅ |
+| 7 | Add `autoFillEnabled: boolean` to frontend `Preferences` type in `preferencesService.ts` | ✅ |
+| 8 | Add AI-only `autoFillEnabled` toggle to `SettingsPage` | ✅ |
+| 9 | Revert collapsible section from `JobCreateSheet`; add optional `initialData?: Partial<FormState>` prop | ✅ |
+| 10 | New `ParseListingDialog` — textarea, "Fill fields" (calls `/api/jobs/parse`, loading + error state, passes result to sheet), "Fill manually" (opens sheet empty); `FormState` moved to `src/types/formTypes.ts` (Option B) | ✅ |
+| 11 | Wire "Add job" in `JobTable` — check `hasRole("AiUser")` + `autoFillEnabled` → dialog or sheet | ✅ |
 
 ---
 

--- a/docs/plans/auto-fill-parsing.md
+++ b/docs/plans/auto-fill-parsing.md
@@ -88,8 +88,8 @@ System prompt instructs Claude to extract these fields from raw listing text: `c
 
 | # | Item | Status |
 |---|---|---|
-| 1 | Add `Anthropic:ApiKey` to config + fail-fast validation in `Program.cs` | — |
-| 2 | Add `IParsingService` + `ClaudeParsingService` in `Services/` | — |
+| 1 | Add `Anthropic:ApiKey` to config + fail-fast validation in `Program.cs` | ✅ |
+| 2 | Add `ParsedJobFields` model + `IParsingService` + `ClaudeParsingService` stub in `Services/` (`ParseListingAsync` throws `NotImplementedException` — prompt + implementation pending) | ✅ stub |
 | 3 | Add `ParseListingRequest` DTO + input validation + `POST /api/jobs/parse-listing` with `[Authorize(Policy = "AiEnabled")]` + `[EnableRateLimiting("parse")]` in `JobsController` | — |
 | 4 | Register `ClaudeParsingService` + add `"parse"` rate limit policy (2 per minute per IP) in `Program.cs` | — |
 | 5 | Add collapsible textarea + "Parse" button to Add Job sheet | — |
@@ -116,11 +116,20 @@ Strip surrounding text and attempt JSON parse regardless — log the anomaly but
 ## Dependencies
 
 ### Anthropic
-Official C# NuGet package from Anthropic (v10+). Install: `dotnet add package Anthropic`.
+Official C# NuGet package from Anthropic. Installed: v12.23.0. Install: `dotnet add package Anthropic`.
+
+Confirmed SDK API shape (v12.23.0):
+- Client: `new AnthropicClient(apiKey: apiKey, maxRetries: 0)`
+- Send: `await client.Messages.Create(new MessageCreateParams { ... })`
+- Role enum: `Role.User` (namespace `Anthropic.Models.Messages`)
+- Read response: `response.Content.OfType<TextBlock>().FirstOrDefault()?.Text`
+
+Chosen over the community `Anthropic.SDK` (tghamm): only basic message creation is needed here — the official package covers it, avoids a third-party maintenance dependency, and includes `IChatClient` integration for future provider abstraction.
 
 ---
 
 ## Notes
 
 - `description` is the pasted text passed through directly (not Claude-extracted). No sanitization needed — HTML tags are rejected at validation (400). A browser textarea strips HTML on paste, so HTML in the request body signals a crafted/attacker request, not a real user.
+- `ParsedJobFields.ClosedAt` uses `DateOnly?` (not `DateTime?`) — serializes as `"YYYY-MM-DD"`, which works directly with frontend date inputs. `DateTime?` would produce `"T00:00:00"` suffix that breaks the input value.
 - Tests: mock `IParsingService` in controller tests; no live Claude calls in CI.

--- a/docs/plans/auto-fill-parsing.md
+++ b/docs/plans/auto-fill-parsing.md
@@ -102,12 +102,13 @@ Key decisions:
 | # | Item | Status |
 |---|---|---|
 | 1 | Add `Anthropic:ApiKey` to config + fail-fast validation in `Program.cs` | ✅ |
-| 2 | Add `ParsedJobFields` model + `IParsingService` + `ClaudeParsingService` stub + `ClaudeParsingConfig` | ✅ config; impl pending |
-| 3 | Add `ParseListingRequest` DTO + input validation + `POST /api/jobs/parse` with `[Authorize(Policy = "AiEnabled")]` + `[EnableRateLimiting("parse")]` in `JobsController` | — |
-| 4 | Register `ClaudeParsingService` + add `"parse"` rate limit policy (2 per minute per IP) in `Program.cs` | — |
-| 5 | Add collapsible textarea + "Parse" button to Add Job sheet | — |
-| 6 | Call endpoint on Parse click; show loading and error state | — |
-| 7 | Merge response into form state (empty fields only) | — |
+| 2 | Add `ParsedJobFields` model + `IParsingService` + `ClaudeParsingService` (full impl) + `ClaudeParsingConfig` | ✅ |
+| 3 | Add `ParseListingRequest` DTO + input validation + `POST /api/jobs/parse` with `[Authorize(Policy = "AiEnabled")]` + `[EnableRateLimiting("parse")]` in `JobsController` | ✅ |
+| 4 | Register `ClaudeParsingService` + add `"parse"` rate limit policy (2 per minute per IP) in `Program.cs` | ✅ |
+| 5 | Add controller tests for `POST /api/jobs/parse` — mock `IParsingService`; cover: 200 with partial result, 400 empty input, 400 over 8000 chars, 400 HTML input, 401 unauthenticated, 403 missing `AiEnabled` policy | — |
+| 6 | Add collapsible textarea + "Parse" button to Add Job sheet | — |
+| 7 | Call endpoint on Parse click; show loading and error state | — |
+| 8 | Merge response into form state (empty fields only) | — |
 
 ---
 

--- a/docs/plans/auto-fill-parsing.md
+++ b/docs/plans/auto-fill-parsing.md
@@ -132,11 +132,16 @@ Strip surrounding text and attempt JSON parse regardless — log the anomaly but
 ### Anthropic
 Official C# NuGet package from Anthropic. Installed: v12.23.0. Install: `dotnet add package Anthropic`.
 
-Confirmed SDK API shape (v12.23.0):
-- Client: `new AnthropicClient(apiKey: apiKey, maxRetries: 0)`
+**SDK API shape — v12.23.0 — PARTIALLY WRONG. Build errors found 2026-05-24:**
+
+| Line | Error | Detail |
+|---|---|---|
+| 36 | `CS1739` | `AnthropicClient` has no named parameter `apiKey`. `new AnthropicClient(apiKey: apiKey, maxRetries: 0)` does not compile. Correct constructor signature is unknown — must be derived from local NuGet cache inspection, not official docs. Related to `ClientOptions.cs` in the SDK. |
+| 50 | `CA2021` | `ContentBlock` and `TextBlock` are incompatible types; `response.Content.OfType<TextBlock>()` always returns empty. The plan's documented response-reading API is wrong. |
+
+Known-good (not implicated by build errors):
 - Send: `await client.Messages.Create(new MessageCreateParams { ... })`
 - Role enum: `Role.User` (namespace `Anthropic.Models.Messages`)
-- Read response: `response.Content.OfType<TextBlock>().FirstOrDefault()?.Text`
 
 Chosen over the community `Anthropic.SDK` (tghamm): only basic message creation is needed here — the official package covers it, avoids a third-party maintenance dependency, and includes `IChatClient` integration for future provider abstraction.
 

--- a/docs/plans/auto-fill-parsing.md
+++ b/docs/plans/auto-fill-parsing.md
@@ -134,11 +134,12 @@ Community C# NuGet package. Install: `dotnet add package Anthropic.SDK`.
 
 **Switched from official `Anthropic` package (v12.23.0).** Official package is auto-generated from the API spec (Stainless) — not human-maintained C#. Auto-generated code does not follow C# conventions: response types use a discriminated union with no ergonomic helpers; `OfType<TextBlock>()` silently returns empty (CA2021). "Actively maintained" means API-spec-synchronized only, not C# experience maintained. tghamm uses standard C# inheritance — idiomatic, documented, maintainable. Extra dependency is the correct tradeoff when the official package harms maintainability.
 
-**SDK API shape — verified from tghamm README 2026-05-24:**
-- Client: `new AnthropicClient(apiKey)` — plain HttpClient, no retries by default
+**SDK API shape — verified from tghamm README + build 2026-05-24:**
+- Namespace: `Anthropic.SDK.Messaging` (not `Anthropic.SDK.Messages` as README implies)
+- Client: `new AnthropicClient(apiKey, new HttpClient())` — explicit no-retry HttpClient; fail fast by design
 - Send: `await client.Messages.GetClaudeMessageAsync(new MessageParameters { ... })`
 - Role: `RoleType.User`; Message param: `new Message(RoleType.User, text)`
-- Read response: `response.Content.OfType<TextContent>().First().Text` ✅
+- Read response: `response.Content.OfType<TextContent>().FirstOrDefault()?.Text ?? string.Empty` ✅
 
 ---
 

--- a/job-tracker-ui/src/components/JobCreateSheet.tsx
+++ b/job-tracker-ui/src/components/JobCreateSheet.tsx
@@ -33,25 +33,8 @@ import {
   MAX_SOURCE_LENGTH,
 } from "@/lib/validationConstants"
 import { JobStatus, Priority, WorkMode, formatEnumLabel } from "@/types/enums"
+import type { FormState } from "@/types/formTypes"
 import { useEffect, useState } from "react"
-
-// FormState represents the internal state of the job edit form
-interface FormState {
-  company: string
-  role: string
-  status: JobStatus
-  priority: Priority
-  appliedAt: Date | undefined
-  closedAt: Date | undefined
-  description: string
-  notes: string
-  jobUrl: string
-  source: string
-  salaryMin: number | ""
-  salaryMax: number | ""
-  location: string
-  workMode: WorkMode | ""
-}
 
 
 // Default form state for creating a new job, with empty fields and default status/priority

--- a/job-tracker-ui/src/components/JobCreateSheet.tsx
+++ b/job-tracker-ui/src/components/JobCreateSheet.tsx
@@ -33,7 +33,6 @@ import {
   MAX_SOURCE_LENGTH,
 } from "@/lib/validationConstants"
 import { JobStatus, Priority, WorkMode, formatEnumLabel } from "@/types/enums"
-import { ChevronDown } from "lucide-react"
 import { useEffect, useState } from "react"
 
 // FormState represents the internal state of the job edit form
@@ -80,27 +79,24 @@ const defaultForm: FormState = {
 interface JobCreateSheetProps {
   open: boolean
   onOpenChange: (open: boolean) => void
+  initialData?: Partial<FormState>
 }
 
 /**
  * JobCreateSheet component provides a form for editing job details.
  * It uses a Sheet component for the UI and manages form state internally.
  */
-export function JobCreateSheet({ open, onOpenChange }: JobCreateSheetProps) {
+export function JobCreateSheet({ open, onOpenChange, initialData }: JobCreateSheetProps) {
 
   const [form, setForm] = useState<FormState>(defaultForm)
   const { mutate: createJob, isPending } = useCreateJob()
   const [errors, setErrors] = useState<{ company?: string; role?: string; jobUrl?: string; salary?: string }>({})
-  const [pasteOpen, setPasteOpen] = useState(false)
-  const [listingText, setListingText] = useState("")
 
-  // Reset form when sheet opens with default values
+  // Reset merges defaultForm with initialData so parsed fields pre-fill the form
   useEffect(() => {
     if (open) {
-      setForm(defaultForm)
+      setForm({ ...defaultForm, ...initialData })
       setErrors({})
-      setPasteOpen(false)
-      setListingText("")
     }
   }, [open])
 
@@ -155,32 +151,6 @@ export function JobCreateSheet({ open, onOpenChange }: JobCreateSheetProps) {
         </SheetHeader>
 
         {/* form fields go here */}
-
-        {/* Auto-fill section*/}
-        <div className="space-y-1.5">
-          <button
-            type="button"
-            className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
-            onClick={() => setPasteOpen(v => !v)}
-          >
-            <ChevronDown className={`h-4 w-4 transition-transform ${pasteOpen ? "rotate-180" : ""}`} />
-            Auto-fill job details
-          </button>
-          {pasteOpen && (
-            <div className="space-y-2">
-              <Textarea
-                value={listingText}
-                onChange={e => setListingText(e.target.value)}
-                placeholder="Paste the job description here..."
-                rows={5}
-                maxLength={8000}
-              />
-              <Button type="button" variant="secondary" size="sm">
-                Fill fields
-              </Button>
-            </div>
-          )}
-        </div>
 
         {/* Edit Company */}
         <div className="space-y-1.5">

--- a/job-tracker-ui/src/components/JobCreateSheet.tsx
+++ b/job-tracker-ui/src/components/JobCreateSheet.tsx
@@ -156,7 +156,7 @@ export function JobCreateSheet({ open, onOpenChange }: JobCreateSheetProps) {
 
         {/* form fields go here */}
 
-        {/* Paste listing — collapsible; expands to reveal textarea and Parse button */}
+        {/* Auto-fill section*/}
         <div className="space-y-1.5">
           <button
             type="button"
@@ -164,19 +164,19 @@ export function JobCreateSheet({ open, onOpenChange }: JobCreateSheetProps) {
             onClick={() => setPasteOpen(v => !v)}
           >
             <ChevronDown className={`h-4 w-4 transition-transform ${pasteOpen ? "rotate-180" : ""}`} />
-            Paste job listing
+            Auto-fill job details
           </button>
           {pasteOpen && (
             <div className="space-y-2">
               <Textarea
                 value={listingText}
                 onChange={e => setListingText(e.target.value)}
-                placeholder="Paste the raw job listing text here..."
+                placeholder="Paste the job description here..."
                 rows={5}
                 maxLength={8000}
               />
               <Button type="button" variant="secondary" size="sm">
-                Parse
+                Fill fields
               </Button>
             </div>
           )}

--- a/job-tracker-ui/src/components/JobCreateSheet.tsx
+++ b/job-tracker-ui/src/components/JobCreateSheet.tsx
@@ -156,6 +156,32 @@ export function JobCreateSheet({ open, onOpenChange }: JobCreateSheetProps) {
 
         {/* form fields go here */}
 
+        {/* Paste listing — collapsible; expands to reveal textarea and Parse button */}
+        <div className="space-y-1.5">
+          <button
+            type="button"
+            className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+            onClick={() => setPasteOpen(v => !v)}
+          >
+            <ChevronDown className={`h-4 w-4 transition-transform ${pasteOpen ? "rotate-180" : ""}`} />
+            Paste job listing
+          </button>
+          {pasteOpen && (
+            <div className="space-y-2">
+              <Textarea
+                value={listingText}
+                onChange={e => setListingText(e.target.value)}
+                placeholder="Paste the raw job listing text here..."
+                rows={5}
+                maxLength={8000}
+              />
+              <Button type="button" variant="secondary" size="sm">
+                Parse
+              </Button>
+            </div>
+          )}
+        </div>
+
         {/* Edit Company */}
         <div className="space-y-1.5">
           <Label htmlFor="company">Company</Label>

--- a/job-tracker-ui/src/components/JobCreateSheet.tsx
+++ b/job-tracker-ui/src/components/JobCreateSheet.tsx
@@ -33,6 +33,7 @@ import {
   MAX_SOURCE_LENGTH,
 } from "@/lib/validationConstants"
 import { JobStatus, Priority, WorkMode, formatEnumLabel } from "@/types/enums"
+import { ChevronDown } from "lucide-react"
 import { useEffect, useState } from "react"
 
 // FormState represents the internal state of the job edit form
@@ -90,12 +91,16 @@ export function JobCreateSheet({ open, onOpenChange }: JobCreateSheetProps) {
   const [form, setForm] = useState<FormState>(defaultForm)
   const { mutate: createJob, isPending } = useCreateJob()
   const [errors, setErrors] = useState<{ company?: string; role?: string; jobUrl?: string; salary?: string }>({})
+  const [pasteOpen, setPasteOpen] = useState(false)
+  const [listingText, setListingText] = useState("")
 
   // Reset form when sheet opens with default values
   useEffect(() => {
     if (open) {
       setForm(defaultForm)
       setErrors({})
+      setPasteOpen(false)
+      setListingText("")
     }
   }, [open])
 

--- a/job-tracker-ui/src/components/JobTable.tsx
+++ b/job-tracker-ui/src/components/JobTable.tsx
@@ -195,7 +195,7 @@ const TAB_STYLES = {
 
 export function JobTable() {
   const { data: jobs, isPending, isError, error } = useJobs();
-  // AI users see ParseListingDialog first; parsed fields flow into the sheet via initialData
+  // AI users see ParseListingDialog first, non-AI sers see JobCreateSheet directly
   const [parseOpen, setParseOpen] = useState(false);
   const [sheetOpen, setSheetOpen] = useState(false);
   const [initialData, setInitialData] = useState<Partial<FormState> | undefined>(undefined);
@@ -255,6 +255,26 @@ export function JobTable() {
 
   if (isPending) return <p>Loading...</p>;
   if (isError) return <p>{error instanceof MaintenanceError ? error.message : "Something went wrong."}</p>;
+
+  // Opens dialog for AI users with auto-fill on; otherwise opens sheet directly
+  function handleAddJob() {
+    if (hasRole("AiUser") && (prefs?.autoFillEnabled ?? true)) {
+      setParseOpen(true);
+    } else {
+      setInitialData(undefined);
+      setSheetOpen(true);
+    }
+  }
+
+  function handleFill(data: Partial<FormState>) {
+    setInitialData(data);
+    setSheetOpen(true);
+  }
+
+  function handleFillManually() {
+    setInitialData(undefined);
+    setSheetOpen(true);
+  }
 
   const sortProps = { activeField: sortField, dir: sortDir, onSort: setSort };
   const showControls = activeTab !== "rejected";

--- a/job-tracker-ui/src/components/JobTable.tsx
+++ b/job-tracker-ui/src/components/JobTable.tsx
@@ -288,7 +288,7 @@ export function JobTable() {
         <Button
           variant="outline"
           className="shadow-xs hover:bg-secondary"
-          onClick={() => setAddOpen(true)}
+          onClick={handleAddJob}
         >
           <Plus className="mr-2 h-4 w-4" />
           Add New Job
@@ -540,7 +540,8 @@ export function JobTable() {
       )}
       </div>
 
-      <JobCreateSheet open={addOpen} onOpenChange={setAddOpen} />
+      <ParseListingDialog open={parseOpen} onOpenChange={setParseOpen} onFill={handleFill} onFillManually={handleFillManually} />
+      <JobCreateSheet open={sheetOpen} onOpenChange={setSheetOpen} initialData={initialData} />
     </div>
   );
 }

--- a/job-tracker-ui/src/components/JobTable.tsx
+++ b/job-tracker-ui/src/components/JobTable.tsx
@@ -540,7 +540,12 @@ export function JobTable() {
       )}
       </div>
 
-      <ParseListingDialog open={parseOpen} onOpenChange={setParseOpen} onFill={handleFill} onFillManually={handleFillManually} />
+      <ParseListingDialog
+        open={parseOpen}
+        onOpenChange={setParseOpen}
+        onFill={handleFill}
+        onFillManually={handleFillManually}
+      />
       <JobCreateSheet open={sheetOpen} onOpenChange={setSheetOpen} initialData={initialData} />
     </div>
   );

--- a/job-tracker-ui/src/components/JobTable.tsx
+++ b/job-tracker-ui/src/components/JobTable.tsx
@@ -25,8 +25,11 @@ import { ArrowDown, ArrowUp, ArrowUpDown, ListFilter, Plus } from "lucide-react"
 import { useMemo, useState } from "react";
 import { useNavigate } from "react-router";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { hasRole } from "@/lib/auth";
+import type { FormState } from "@/types/formTypes";
 import { ColumnToggle } from "./ColumnToggle";
 import { JobCreateSheet } from "./JobCreateSheet";
+import { ParseListingDialog } from "./ParseListingDialog";
 import { PriorityDot } from "./ui/PriorityDot";
 import { StatusBadge } from "./ui/StatusBadge";
 
@@ -192,7 +195,10 @@ const TAB_STYLES = {
 
 export function JobTable() {
   const { data: jobs, isPending, isError, error } = useJobs();
-  const [addOpen, setAddOpen] = useState(false);
+  // AI users see ParseListingDialog first; parsed fields flow into the sheet via initialData
+  const [parseOpen, setParseOpen] = useState(false);
+  const [sheetOpen, setSheetOpen] = useState(false);
+  const [initialData, setInitialData] = useState<Partial<FormState> | undefined>(undefined);
   const navigate = useNavigate();
   // visibleColumns from prefs; fall back to defaults while loading.
   const { data: prefs } = usePreferences();

--- a/job-tracker-ui/src/components/ParseListingDialog.tsx
+++ b/job-tracker-ui/src/components/ParseListingDialog.tsx
@@ -23,5 +23,14 @@ export function ParseListingDialog({ open, onOpenChange, onFill, onFillManually 
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
+  // Clears transient state when the dialog closes (X, Escape, backdrop)
+  function handleOpenChange(nextOpen: boolean) {}
+
+  // Calls the parse API and hands the converted result to the parent
+  async function handleFill() {}
+
+  // Closes the dialog then tells the parent to open the sheet empty
+  function handleFillManually() {}
+
   return <></>
 }

--- a/job-tracker-ui/src/components/ParseListingDialog.tsx
+++ b/job-tracker-ui/src/components/ParseListingDialog.tsx
@@ -18,6 +18,14 @@ interface ParseListingDialogProps {
   onFillManually: () => void
 }
 
+// Parse endpoint returns DateOnly ("YYYY-MM-DD"), which new Date() treats as UTC midnight —
+// shifting the date backwards in UTC+ time zones. The 3-arg constructor always uses local time.
+// JS Date months are 0-indexed (0 = Jan); DateOnly strings are 1-indexed, hence m - 1.
+function parseDateOnly(s: string): Date {
+  const [y, m, d] = s.split("-").map(Number)
+  return new Date(y, m - 1, d)
+}
+
 export function ParseListingDialog({ open, onOpenChange, onFill, onFillManually }: ParseListingDialogProps) {
   const [text, setText] = useState("")
   const [loading, setLoading] = useState(false)

--- a/job-tracker-ui/src/components/ParseListingDialog.tsx
+++ b/job-tracker-ui/src/components/ParseListingDialog.tsx
@@ -1,0 +1,27 @@
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Textarea } from "@/components/ui/textarea"
+import { parseListing } from "@/services/parseService"
+import type { FormState } from "@/types/formTypes"
+import { useState } from "react"
+
+interface ParseListingDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onFill: (data: Partial<FormState>) => void
+  onFillManually: () => void
+}
+
+export function ParseListingDialog({ open, onOpenChange, onFill, onFillManually }: ParseListingDialogProps) {
+  const [text, setText] = useState("")
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  return <></>
+}

--- a/job-tracker-ui/src/components/ParseListingDialog.tsx
+++ b/job-tracker-ui/src/components/ParseListingDialog.tsx
@@ -41,7 +41,23 @@ export function ParseListingDialog({ open, onOpenChange, onFill, onFillManually 
   }
 
   // Calls the parse API and hands the converted result to the parent
-  async function handleFill() {}
+  async function handleFill() {
+    setError(null)
+    setLoading(true)
+    try {
+      const fields = await parseListing(text)
+      const initialData: Partial<FormState> = {
+        ...fields,
+        closedAt: fields.closedAt ? parseDateOnly(fields.closedAt) : undefined,
+      }
+      onFill(initialData)
+      handleOpenChange(false)
+    } catch {
+      setError("Something went wrong. Please try again.")
+    } finally {
+      setLoading(false)
+    }
+  }
 
   // Closes the dialog then tells the parent to open the sheet empty
   function handleFillManually() {}

--- a/job-tracker-ui/src/components/ParseListingDialog.tsx
+++ b/job-tracker-ui/src/components/ParseListingDialog.tsx
@@ -9,6 +9,7 @@ import {
 import { Textarea } from "@/components/ui/textarea"
 import { parseListing } from "@/services/parseService"
 import type { FormState } from "@/types/formTypes"
+import { Sparkles } from "lucide-react"
 import { useState } from "react"
 
 interface ParseListingDialogProps {
@@ -69,11 +70,14 @@ export function ParseListingDialog({ open, onOpenChange, onFill, onFillManually 
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="sm:max-w-lg flex flex-col max-h-[85vh]">
         <DialogHeader>
-          <DialogTitle>Auto-fill job details</DialogTitle>
+          <DialogTitle className="flex items-center gap-2">
+            <Sparkles className="h-4 w-4 text-primary" />
+            Auto-fill job details
+          </DialogTitle>
         </DialogHeader>
         <div className="space-y-3 overflow-y-auto flex-1 min-h-0">
           <p className="text-sm text-muted-foreground">
-            Paste the job listing text below and Claude will extract the details for you.
+            Paste the job listing text below and the details will be extracted automatically.
           </p>
           <Textarea
             value={text}

--- a/job-tracker-ui/src/components/ParseListingDialog.tsx
+++ b/job-tracker-ui/src/components/ParseListingDialog.tsx
@@ -85,9 +85,6 @@ export function ParseListingDialog({ open, onOpenChange, onFill, onFillManually 
           {error && <p className="text-sm text-destructive">{error}</p>}
         </div>
         <DialogFooter className="flex-col sm:flex-row gap-2">
-          <Button variant="ghost" onClick={() => handleOpenChange(false)} disabled={loading}>
-            Cancel
-          </Button>
           <Button variant="outline" onClick={handleFillManually} disabled={loading}>
             Fill manually
           </Button>

--- a/job-tracker-ui/src/components/ParseListingDialog.tsx
+++ b/job-tracker-ui/src/components/ParseListingDialog.tsx
@@ -60,7 +60,10 @@ export function ParseListingDialog({ open, onOpenChange, onFill, onFillManually 
   }
 
   // Closes the dialog then tells the parent to open the sheet empty
-  function handleFillManually() {}
+  function handleFillManually() {
+    handleOpenChange(false)
+    onFillManually()
+  }
 
   return <></>
 }

--- a/job-tracker-ui/src/components/ParseListingDialog.tsx
+++ b/job-tracker-ui/src/components/ParseListingDialog.tsx
@@ -67,11 +67,11 @@ export function ParseListingDialog({ open, onOpenChange, onFill, onFillManually 
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent className="sm:max-w-lg">
+      <DialogContent className="sm:max-w-lg flex flex-col max-h-[85vh]">
         <DialogHeader>
           <DialogTitle>Auto-fill job details</DialogTitle>
         </DialogHeader>
-        <div className="space-y-3">
+        <div className="space-y-3 overflow-y-auto flex-1 min-h-0">
           <p className="text-sm text-muted-foreground">
             Paste the job listing text below and Claude will extract the details for you.
           </p>

--- a/job-tracker-ui/src/components/ParseListingDialog.tsx
+++ b/job-tracker-ui/src/components/ParseListingDialog.tsx
@@ -24,7 +24,13 @@ export function ParseListingDialog({ open, onOpenChange, onFill, onFillManually 
   const [error, setError] = useState<string | null>(null)
 
   // Clears transient state when the dialog closes (X, Escape, backdrop)
-  function handleOpenChange(nextOpen: boolean) {}
+  function handleOpenChange(nextOpen: boolean) {
+    if (!nextOpen) {
+      setText("")
+      setError(null)
+    }
+    onOpenChange(nextOpen)
+  }
 
   // Calls the parse API and hands the converted result to the parent
   async function handleFill() {}

--- a/job-tracker-ui/src/components/ParseListingDialog.tsx
+++ b/job-tracker-ui/src/components/ParseListingDialog.tsx
@@ -65,5 +65,37 @@ export function ParseListingDialog({ open, onOpenChange, onFill, onFillManually 
     onFillManually()
   }
 
-  return <></>
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Auto-fill job details</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-3">
+          <p className="text-sm text-muted-foreground">
+            Paste the job listing text below and Claude will extract the details for you.
+          </p>
+          <Textarea
+            value={text}
+            onChange={e => setText(e.target.value)}
+            placeholder="Paste job listing here..."
+            rows={8}
+            disabled={loading}
+          />
+          {error && <p className="text-sm text-destructive">{error}</p>}
+        </div>
+        <DialogFooter className="flex-col sm:flex-row gap-2">
+          <Button variant="ghost" onClick={() => handleOpenChange(false)} disabled={loading}>
+            Cancel
+          </Button>
+          <Button variant="outline" onClick={handleFillManually} disabled={loading}>
+            Fill manually
+          </Button>
+          <Button onClick={handleFill} disabled={loading || !text.trim()}>
+            {loading ? "Filling..." : "Fill fields"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
 }

--- a/job-tracker-ui/src/pages/SettingsPage.tsx
+++ b/job-tracker-ui/src/pages/SettingsPage.tsx
@@ -1,8 +1,11 @@
 import NavBar from "@/components/NavBar"
 import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { usePreferences, useUpdatePreferences } from "@/hooks/preferencesQuery"
 import { ApiError } from "@/lib/api"
+import { hasRole } from "@/lib/auth"
 import { changePassword } from "@/services/authService"
 import { useState } from "react"
 import { useLocation, useNavigate } from "react-router"
@@ -14,6 +17,9 @@ export default function SettingsPage() {
   const navigate = useNavigate()
   // Use the path UserMenu passed via router state; fall back to /jobs on direct URL load
   const from: string = location.state?.from ?? "/jobs"
+
+  const { data: prefs, isLoading: isLoadingPrefs } = usePreferences()
+  const { mutate: mutatePrefs } = useUpdatePreferences()
 
   const [currentPassword, setCurrentPassword] = useState("")
   const [newPassword, setNewPassword] = useState("")
@@ -86,6 +92,26 @@ export default function SettingsPage() {
               </Button>
             </form>
           </section>
+
+          {hasRole("AiUser") && (
+            <section className="mt-6 pt-6 border-t">
+              <h2 className="text-sm font-medium text-muted-foreground mb-4">AI Features</h2>
+              {isLoadingPrefs ? (
+                <p className="text-sm text-muted-foreground">Loading...</p>
+              ) : (
+                <div className="flex items-center gap-3">
+                  <Checkbox
+                    id="autoFill"
+                    checked={prefs?.autoFillEnabled ?? true}
+                    onCheckedChange={checked =>
+                      mutatePrefs({ ...prefs!, autoFillEnabled: checked === true })
+                    }
+                  />
+                  <Label htmlFor="autoFill">Show auto-fill dialog when adding a job</Label>
+                </div>
+              )}
+            </section>
+          )}
         </div>
       </div>
     </div>

--- a/job-tracker-ui/src/services/parseService.ts
+++ b/job-tracker-ui/src/services/parseService.ts
@@ -1,0 +1,28 @@
+import { apiFetch, handleResponse } from "@/lib/api"
+import type { WorkMode } from "@/types/enums"
+
+const BASE_URL = import.meta.env.VITE_API_BASE_URL
+
+// Shape the backend returns from POST /api/jobs/parse.
+// All fields optional — Claude omits fields it could not extract.
+export type ParsedJobFields = {
+  company?: string
+  role?: string
+  jobUrl?: string
+  location?: string
+  workMode?: WorkMode
+  salaryMin?: number
+  salaryMax?: number
+  closedAt?: string  // YYYY-MM-DD
+  source?: string
+  description?: string
+}
+
+export async function parseListing(text: string): Promise<ParsedJobFields> {
+  const response = await apiFetch(`${BASE_URL}/jobs/parse`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ text }),
+  })
+  return handleResponse<ParsedJobFields>(response)
+}

--- a/job-tracker-ui/src/services/preferencesService.ts
+++ b/job-tracker-ui/src/services/preferencesService.ts
@@ -7,6 +7,7 @@ const BASE_URL = import.meta.env.VITE_API_BASE_URL;
 // Shape the backend sends and expects at /api/account/preferences.
 export type Preferences = {
   visibleColumns: ColumnKey[];
+  autoFillEnabled: boolean;
 };
 
 /**

--- a/job-tracker-ui/src/types/formTypes.ts
+++ b/job-tracker-ui/src/types/formTypes.ts
@@ -1,6 +1,6 @@
 import type { JobStatus, Priority, WorkMode } from "@/types/enums"
 
-// FormState represents the internal state of the job create/edit form
+// FormState represents the internal state of the job create form
 export interface FormState {
   company: string
   role: string

--- a/job-tracker-ui/src/types/formTypes.ts
+++ b/job-tracker-ui/src/types/formTypes.ts
@@ -1,0 +1,19 @@
+import type { JobStatus, Priority, WorkMode } from "@/types/enums"
+
+// FormState represents the internal state of the job create/edit form
+export interface FormState {
+  company: string
+  role: string
+  status: JobStatus
+  priority: Priority
+  appliedAt: Date | undefined
+  closedAt: Date | undefined
+  description: string
+  notes: string
+  jobUrl: string
+  source: string
+  salaryMin: number | ""
+  salaryMax: number | ""
+  location: string
+  workMode: WorkMode | ""
+}


### PR DESCRIPTION
This pull request introduces AI-powered job listing parsing into the backend, enabling extraction of structured job fields from pasted text using the Claude API. It adds a new endpoint for parsing, enforces validation on input, and includes tests for the new functionality. The implementation is modular, with clear abstractions and rate limiting to control API usage.

**AI Parsing Feature Integration**

* Added the `IParsingService` abstraction and its production implementation `ClaudeParsingService`, which calls the Claude API to extract structured job fields from raw text. The service uses a strict JSON contract and logs contract violations for monitoring. (`JobTrackerApi/Services/IParsingService.cs`, `JobTrackerApi/Services/ClaudeParsingService.cs`, `JobTrackerApi/Services/ClaudeParsingConfig.cs`, `JobTrackerApi/Models/ParsedJobFields.cs`, [[1]](diffhunk://#diff-4bc6b361489bd2b1f2688a831c5e8dbbde30fd42f10b78cc29f8fdef5c2b06e0R1-R10) [[2]](diffhunk://#diff-1f11cc94e5e64958b6d641d1fa7c8b0b28a9dd0f73b33d1ccd949f77cac7efb4R1-R114) [[3]](diffhunk://#diff-f2639ecef9e2322e962f7c66c6fd0a1505bd525e991aaf6ab5748e4a2ee4b9c4R1-R51) [[4]](diffhunk://#diff-c48a4f164ba6720617d3892fee6490e8d24f744d3554bc5b71550a700ab15a81R1-R57)
* Registered the parsing service in DI and required the Anthropic API key in configuration. Added the `Anthropic.SDK` NuGet package. (`JobTrackerApi/Program.cs`, `JobTrackerApi/JobTrackerApi.csproj`, [[1]](diffhunk://#diff-0ce0194449609aaffce0dadf0278109a6526b3b92524488758e47d0bfe9c8b6eR119-R125) [[2]](diffhunk://#diff-0ce0194449609aaffce0dadf0278109a6526b3b92524488758e47d0bfe9c8b6eR155-R157) [[3]](diffhunk://#diff-085c836fe4d7501f908564e83461197d631821e85d2d44aadb79b1b15726b51aR10)

**API Endpoint and Validation**

* Added a new POST `/api/jobs/parse` endpoint, protected by the `AiEnabled` policy and rate-limited (2 requests per minute per user), which returns parsed job fields. (`JobTrackerApi/Controllers/JobsController.cs`, [JobTrackerApi/Controllers/JobsController.csL213-R225](diffhunk://#diff-a3647cf4d1170b23ac3d706c4a12e2734b8c71e985974fb0d7161c14e2010c9bL213-R225))
* Introduced the `ParseListingRequest` model with validation: rejects empty input, input over 8000 characters, and HTML content. (`JobTrackerApi/Models/ParseListingRequest.cs`, [JobTrackerApi/Models/ParseListingRequest.csR1-R18](diffhunk://#diff-033e20fad730ad03d11dae32bd15f15a4bccb1cbe5403fe665215e5a860a076cR1-R18))

**Testing**

* Extended `JobsControllerTests` to mock the parsing service and test validation rules and successful parsing scenarios for the new endpoint. (`JobTrackerApi.Tests/JobsControllerTests.cs`, [[1]](diffhunk://#diff-9d32cf23956737b6e0435e0352311fbe67907d85b06a53c8ab4c6b01b6ef1f95R17) [[2]](diffhunk://#diff-9d32cf23956737b6e0435e0352311fbe67907d85b06a53c8ab4c6b01b6ef1f95R29-R33) [[3]](diffhunk://#diff-9d32cf23956737b6e0435e0352311fbe67907d85b06a53c8ab4c6b01b6ef1f95R447-R517)

**Documentation and Plans**

* Updated documentation to reflect the new AI parsing workflow and clarified configuration steps for production. (`docs/plans/auto-fill-parsing.md`, `docs/plans/ai-access-admin.md`, [[1]](diffhunk://#diff-e5d75a3f4fc0ac145e552251829bcb4da03552371f9dac3a72912b231b7d5dacL5-R5) [[2]](diffhunk://#diff-e965eb4f8724cb5b580c51070c61370378f286eeab234c52ed6b32e127e39041L70-R70)

These changes lay the foundation for AI-assisted job entry, allowing users to quickly pre-fill job forms from pasted listings while maintaining input integrity and backend contract safety.