### PR TITLE
Refactor reminder handling to preserve preference fields

### DIFF
--- a/JobTrackerApi/Controllers/AccountController.cs
+++ b/JobTrackerApi/Controllers/AccountController.cs
@@ -54,6 +54,8 @@ public class AccountController : ControllerBase
         return Ok(prefs ?? new UserPreferencesDto { VisibleColumns = DefaultColumns });
     }
 
+    // PUT replaces the entire preferences blob — partial updates require spreading on the frontend.
+    // TODO: refactor to PATCH with merge semantics so callers only send fields they own (see docs/plans/preferences-patch-refactor.md)
     [HttpPut("preferences")]
     public async Task<IActionResult> UpdatePreferences(UserPreferencesDto dto)
     {

--- a/docs/plans/auto-fill-parsing.md
+++ b/docs/plans/auto-fill-parsing.md
@@ -116,6 +116,7 @@ Key decisions:
 | 9 | Revert collapsible section from `JobCreateSheet`; add optional `initialData?: Partial<FormState>` prop | ✅ |
 | 10 | New `ParseListingDialog` — textarea, "Fill fields" (calls `/api/jobs/parse`, loading + error state, passes result to sheet), "Fill manually" (opens sheet empty); `FormState` moved to `src/types/formTypes.ts` (Option B) | ✅ |
 | 11 | Wire "Add job" in `JobTable` — check `hasRole("AiUser")` + `autoFillEnabled` → dialog or sheet | ✅ |
+| 12 | Wire `ANTHROPIC_API_KEY` into production pipeline — export in `deploy.yml`, inject via `compose.prod.yml`, document in `deployment-setup.md` and `.env.example` | ✅ |
 
 ---
 

--- a/docs/plans/preferences-patch-refactor.md
+++ b/docs/plans/preferences-patch-refactor.md
@@ -1,0 +1,25 @@
+# Preferences — Refactor PUT to PATCH
+
+## Problem
+
+`PUT /api/account/preferences` replaces the entire preferences blob. Every caller must
+spread the existing prefs before overriding their fields, coupling unrelated components
+to the full `Preferences` shape. Each new preference field added to the backend requires
+auditing all frontend callers.
+
+## Decision
+
+Refactor to `PATCH /api/account/preferences` with merge semantics:
+- Backend reads current prefs, merges the partial fields, re-saves
+- Frontend `updatePreferences` accepts `Partial<Preferences>` and sends `PATCH`
+- Each component sends only the fields it owns — no spreading required
+
+## What changes
+
+| Location | Change |
+|---|---|
+| `AccountController.cs` | `[HttpPut]` → `[HttpPatch]`; read current prefs, merge, re-save |
+| `UserPreferencesDto` | All fields become nullable/optional for the patch shape |
+| `preferencesService.ts` | Method → `PATCH`; param type → `Partial<Preferences>` |
+| `ColumnToggle.tsx` | Drop spread — send `{ visibleColumns: draft }` only |
+| `SettingsPage.tsx` | Drop spread — send `{ autoFillEnabled: ... }` only |

--- a/job-tracker-ui/src/components/ColumnToggle.tsx
+++ b/job-tracker-ui/src/components/ColumnToggle.tsx
@@ -31,7 +31,9 @@ export function ColumnToggle() {
       // Snapshot on open so draft always starts from the latest saved value, not a stale one.
       setDraft(prefs?.visibleColumns ?? DEFAULT_VISIBLE);
     } else {
-      mutate({ visibleColumns: draft });
+      // Spread prefs to preserve all other preference fields — PUT replaces the whole object.
+      // TODO: switch to PATCH so each component only sends the fields it owns (see docs/plans/preferences-patch-refactor.md)
+      mutate({ ...prefs!, visibleColumns: draft });
     }
     setOpen(next);
   }

--- a/job-tracker-ui/src/services/preferencesService.ts
+++ b/job-tracker-ui/src/services/preferencesService.ts
@@ -26,6 +26,8 @@ export async function getPreferences(): Promise<Preferences> {
  * @returns A promise that resolves when the preferences are successfully saved.
  * @throws An error if the fetch operation fails.
  */
+// PUT replaces the full Preferences object — callers must spread existing prefs before overriding fields.
+// TODO: switch to PATCH so callers only send the fields they own (see docs/plans/preferences-patch-refactor.md)
 export async function updatePreferences(prefs: Preferences): Promise<void> {
   const response = await apiFetch(`${BASE_URL}/account/preferences`, {
     method: "PUT",


### PR DESCRIPTION
This pull request documents and prepares for a planned refactor to the user preferences update API, aiming to improve maintainability and decouple frontend components from backend data structure changes. The current implementation uses a PUT endpoint that requires clients to send the entire preferences object, but the proposed change will switch to a PATCH endpoint with merge semantics, allowing partial updates. Several code comments and a new planning document have been added to guide this transition, and related documentation has been updated.

**Preparation for PATCH refactor in user preferences:**

* Added detailed planning document `preferences-patch-refactor.md` outlining the problems with the current PUT approach and specifying the planned migration to a PATCH endpoint for user preferences, including required backend and frontend changes.
* Added TODO comments and explanatory notes to `AccountController.cs`, `preferencesService.ts`, and `ColumnToggle.tsx` highlighting that PUT currently replaces the entire preferences object and referencing the upcoming PATCH refactor. [[1]](diffhunk://#diff-4526bdb467c77c538a91d044b8fd126628ab3d831fae2317a95889f551808f70R57-R58) [[2]](diffhunk://#diff-eda4a0cbfcc896f645739f76e4c3f80b88678526e230d084b00d628fc799aeaeR29-R30) [[3]](diffhunk://#diff-66efc98f21a2eb96be8cddb09ecd59279331f057dc9ea91a2ac920990b3b7e1aL34-R36)

**Documentation updates:**

* Updated the auto-fill parsing plan to note that wiring of the `ANTHROPIC_API_KEY` into the production pipeline is complete, including changes to deployment and documentation files.