### PR TITLE
Feat/no response status

### DIFF
--- a/JobTrackerApi/Models/Enums/JobStatus.cs
+++ b/JobTrackerApi/Models/Enums/JobStatus.cs
@@ -8,5 +8,6 @@ public enum JobStatus
     Screening,
     Interview,
     Offered,
-    Rejected
+    Rejected,
+    NoResponse
 }

--- a/docs/plans/no-response-status.md
+++ b/docs/plans/no-response-status.md
@@ -1,0 +1,13 @@
+# NoResponse Status
+
+Tracks decisions made when adding `NoResponse` as a seventh job application status.
+
+## Decisions
+
+- `NoResponse` is appended after `Rejected` in the backend enum (integer value 6). Existing DB rows are unaffected.
+- It is a terminal state. No special transition rules beyond what already applies to `Rejected`.
+- Excluded from the "active" tab in JobTable using the same filter rule as `Rejected`.
+- The "Rejected" tab is renamed "Closed" and shows both `Rejected` and `NoResponse` entries.
+- In Kanban, `NoResponse` gets its own column after `Rejected`. A vertical divider between the two marks it as outside the normal application flow.
+- Display label is "No Response", added via `ENUM_DISPLAY_OVERRIDES` in `enums.ts` (same mechanism as "On-site", "Cover Letter", etc.).
+- `StatusBadge` style uses amber/muted orange to distinguish it from the red used for `Rejected`.

--- a/job-tracker-ui/src/components/JobCreateSheet.tsx
+++ b/job-tracker-ui/src/components/JobCreateSheet.tsx
@@ -172,7 +172,7 @@ export function JobCreateSheet({ open, onOpenChange, initialData }: JobCreateShe
             </SelectTrigger>
             <SelectContent>
               {Object.values(JobStatus).map(s => (
-                <SelectItem key={s} value={s}>{s}</SelectItem>
+                <SelectItem key={s} value={s}>{formatEnumLabel(s)}</SelectItem>
               ))}
             </SelectContent>
           </Select>

--- a/job-tracker-ui/src/components/JobEditSheet.tsx
+++ b/job-tracker-ui/src/components/JobEditSheet.tsx
@@ -228,7 +228,7 @@ export function JobEditSheet({ job, open, onOpenChange }: JobEditSheetProps) {
             </SelectTrigger>
             <SelectContent>
               {Object.values(JobStatus).map(s => (
-                <SelectItem key={s} value={s}>{s}</SelectItem>
+                <SelectItem key={s} value={s}>{formatEnumLabel(s)}</SelectItem>
               ))}
             </SelectContent>
           </Select>

--- a/job-tracker-ui/src/components/JobTable.tsx
+++ b/job-tracker-ui/src/components/JobTable.tsx
@@ -243,7 +243,7 @@ export function JobTable() {
 
     switch (activeTab) {
       case "active":
-        return all.filter((j) => j.status !== JobStatus.Rejected);
+        return all.filter((j) => j.status !== JobStatus.Rejected && j.status !== JobStatus.NoResponse);
       case "closing-soon":
         return all.filter((j) => {
           if (j.status !== JobStatus.Wishlist || !j.closedAt) return false;

--- a/job-tracker-ui/src/components/JobTable.tsx
+++ b/job-tracker-ui/src/components/JobTable.tsx
@@ -122,7 +122,7 @@ function FilterPopover({
               value === opt && "font-medium"
             )}
           >
-            {opt || "All"}
+            {opt ? formatEnumLabel(opt) : "All"}
           </button>
         ))}
       </PopoverContent>

--- a/job-tracker-ui/src/components/JobTable.tsx
+++ b/job-tracker-ui/src/components/JobTable.tsx
@@ -202,7 +202,7 @@ const TAB_STYLES = {
     table:    ["bg-slate-50",                                   "dark:bg-slate-800/40"].join(" "),
     rowHover: ["hover:bg-slate-100",                            "dark:hover:bg-slate-800/60"].join(" "),
   },
-  "rejected": {
+  "closed": {
     tab:      ["!bg-rose-50 !text-rose-800 border-rose-300",    "dark:!bg-rose-900/30 dark:!text-rose-400 dark:border-rose-800"].join(" "),
     table:    ["bg-rose-50",                                    "dark:bg-rose-900/20"].join(" "),
     rowHover: ["hover:bg-rose-100",                             "dark:hover:bg-rose-900/30"].join(" "),
@@ -231,7 +231,7 @@ export function JobTable() {
   // Helper to check column visibility without repeating the scan at every call site.
   const isVisible = (key: ColumnKey) => visibleCols.some((c) => c.key === key);
 
-  const [activeTab, setActiveTab] = useState<"active" | "closing-soon" | "all" | "rejected">("active");
+  const [activeTab, setActiveTab] = useState<"active" | "closing-soon" | "all" | "closed">("active");
 
   // Pre-filter by tab before column filters are applied
   const tabFilteredJobs = useMemo(() => {
@@ -250,8 +250,8 @@ export function JobTable() {
           const d = new Date(j.closedAt);
           return d >= today && d <= in7Days;
         });
-      case "rejected":
-        return all.filter((j) => j.status === JobStatus.Rejected);
+      case "closed":
+        return all.filter((j) => j.status === JobStatus.Rejected || j.status === JobStatus.NoResponse);
       default:
         return all;
     }
@@ -293,7 +293,7 @@ export function JobTable() {
   }
 
   const sortProps = { activeField: sortField, dir: sortDir, onSort: setSort };
-  const showControls = activeTab !== "rejected";
+  const showControls = activeTab !== "closed";
 
   return (
     <div className="flex flex-col gap-4">
@@ -326,7 +326,7 @@ export function JobTable() {
               { value: "active", label: "Active" },
               { value: "closing-soon", label: "Closing Soon" },
               { value: "all", label: "All" },
-              { value: "rejected", label: "Rejected" },
+              { value: "closed", label: "Closed" },
             ] as const
           ).map(({ value, label }) => (
             <TabsTrigger

--- a/job-tracker-ui/src/components/KanbanBoard.tsx
+++ b/job-tracker-ui/src/components/KanbanBoard.tsx
@@ -20,7 +20,7 @@ const COLUMN_BG: Record<JobStatus, string> = {
   Interview: ["bg-purple-50/70", "dark:bg-purple-900/20"].join(" "),
   Offered:   ["bg-green-50/70",  "dark:bg-green-900/20"].join(" "),
   Rejected:   ["bg-red-50/70",    "dark:bg-red-900/20"].join(" "),
-  NoResponse: ["bg-amber-50/70", "dark:bg-amber-900/20"].join(" "),
+  NoResponse: ["bg-orange-50/70", "dark:bg-orange-900/20"].join(" "),
 }
 
 function KanbanCard({ job }: { job: Job }) {

--- a/job-tracker-ui/src/components/KanbanBoard.tsx
+++ b/job-tracker-ui/src/components/KanbanBoard.tsx
@@ -19,7 +19,8 @@ const COLUMN_BG: Record<JobStatus, string> = {
   Screening: ["bg-yellow-50/70", "dark:bg-yellow-900/20"].join(" "),
   Interview: ["bg-purple-50/70", "dark:bg-purple-900/20"].join(" "),
   Offered:   ["bg-green-50/70",  "dark:bg-green-900/20"].join(" "),
-  Rejected:  ["bg-red-50/70",    "dark:bg-red-900/20"].join(" "),
+  Rejected:   ["bg-red-50/70",    "dark:bg-red-900/20"].join(" "),
+  NoResponse: ["bg-amber-50/70", "dark:bg-amber-900/20"].join(" "),
 }
 
 function KanbanCard({ job }: { job: Job }) {
@@ -95,13 +96,19 @@ export function KanbanBoard() {
     <DndContext sensors={sensors} onDragEnd={handleDragEnd}>
       <div className="overflow-x-auto">
         <div className="flex gap-4 min-w-max pb-4">
-          {COLUMNS.map((status) => (
+          {COLUMNS.filter((s) => s !== JobStatus.NoResponse).map((status) => (
             <KanbanColumn
               key={status}
               status={status}
               jobs={jobs.filter((j) => j.status === status)}
             />
           ))}
+          {/* NoResponse is outside the normal application flow */}
+          <div className="w-px self-stretch bg-border mx-1" />
+          <KanbanColumn
+            status={JobStatus.NoResponse}
+            jobs={jobs.filter((j) => j.status === JobStatus.NoResponse)}
+          />
         </div>
       </div>
     </DndContext>

--- a/job-tracker-ui/src/components/ui/StatusBadge.tsx
+++ b/job-tracker-ui/src/components/ui/StatusBadge.tsx
@@ -2,6 +2,7 @@
  * StatusBadge component to display job status with appropriate styling
  */
 import { Badge } from "@/components/ui/badge"
+import { formatEnumLabel } from "@/types/enums"
 import type { JobStatus } from "@/types/enums"
 
 const statusStyles: Record<JobStatus, string> = {
@@ -29,12 +30,16 @@ const statusStyles: Record<JobStatus, string> = {
     "bg-red-100 text-red-700 border border-red-300",
     "dark:bg-red-900/50 dark:text-red-400 dark:border-red-800",
   ].join(" "),
+  NoResponse: [
+    "bg-amber-100 text-amber-700 border border-amber-300",
+    "dark:bg-amber-900/50 dark:text-amber-400 dark:border-amber-800",
+  ].join(" "),
 }
 
 export function StatusBadge({ status, className = "" }: { status: JobStatus; className?: string }) {
   return (
     <Badge className={`${statusStyles[status]} ${className}`}>
-      {status}
+      {formatEnumLabel(status)}
     </Badge>
   )
 }

--- a/job-tracker-ui/src/components/ui/StatusBadge.tsx
+++ b/job-tracker-ui/src/components/ui/StatusBadge.tsx
@@ -31,8 +31,8 @@ const statusStyles: Record<JobStatus, string> = {
     "dark:bg-red-900/50 dark:text-red-400 dark:border-red-800",
   ].join(" "),
   NoResponse: [
-    "bg-amber-100 text-amber-700 border border-amber-300",
-    "dark:bg-amber-900/50 dark:text-amber-400 dark:border-amber-800",
+    "bg-orange-100 text-orange-700 border border-orange-300",
+    "dark:bg-orange-900/50 dark:text-orange-400 dark:border-orange-800",
   ].join(" "),
 }
 

--- a/job-tracker-ui/src/hooks/useJobFilters.ts
+++ b/job-tracker-ui/src/hooks/useJobFilters.ts
@@ -28,6 +28,7 @@ const STATUS_ORDER: Record<string, number> = {
   Interview: 3,
   Offered: 4,
   Rejected: 5,
+  NoResponse: 6,
 };
 
 const PRIORITY_ORDER: Record<string, number> = {

--- a/job-tracker-ui/src/types/enums.ts
+++ b/job-tracker-ui/src/types/enums.ts
@@ -7,7 +7,8 @@ export const JobStatus = {
         Screening: 'Screening',
         Interview: 'Interview',
         Offered: 'Offered',
-        Rejected: 'Rejected'
+        Rejected: 'Rejected',
+        NoResponse: 'NoResponse'
 } as const;
 
 export type JobStatus = typeof JobStatus[keyof typeof JobStatus];
@@ -44,6 +45,7 @@ const ENUM_DISPLAY_OVERRIDES: Record<string, string> = {
   OnSite: "On-site",
   CoverLetter: "Cover Letter",
   ReferenceLetter: "Reference Letter",
+  NoResponse: "No Response",
 };
 
 export function formatEnumLabel(value: string): string {


### PR DESCRIPTION
This pull request introduces a new "No Response" status to the job tracking application, allowing users to distinguish between jobs that were explicitly rejected and those that received no reply. The update includes backend enum changes, UI adjustments for both the Kanban board and job table, and ensures consistent labeling and styling throughout the app.

**Backend and Data Model:**
- Added `NoResponse` as a new value in the `JobStatus` enum, positioned after `Rejected` and treated as a terminal state.

**UI/UX Updates:**

*Job Table and Filtering:*
- The "Rejected" tab is renamed to "Closed" and now displays both `Rejected` and `NoResponse` entries; both are excluded from the "Active" tab. All related filtering logic and tab styles are updated accordingly. [[1]](diffhunk://#diff-7bceb6509ca39c7f56f6499dffe0aa8bae67b391bd3004dd0d8beae2a8895689L205-R205) [[2]](diffhunk://#diff-7bceb6509ca39c7f56f6499dffe0aa8bae67b391bd3004dd0d8beae2a8895689L234-R234) [[3]](diffhunk://#diff-7bceb6509ca39c7f56f6499dffe0aa8bae67b391bd3004dd0d8beae2a8895689L246-R254) [[4]](diffhunk://#diff-7bceb6509ca39c7f56f6499dffe0aa8bae67b391bd3004dd0d8beae2a8895689L296-R296) [[5]](diffhunk://#diff-7bceb6509ca39c7f56f6499dffe0aa8bae67b391bd3004dd0d8beae2a8895689L329-R329)
- The filter popover and status selectors now use formatted display labels for statuses, including the new "No Response" label. [[1]](diffhunk://#diff-7bceb6509ca39c7f56f6499dffe0aa8bae67b391bd3004dd0d8beae2a8895689L125-R125) [[2]](diffhunk://#diff-93e9f40486f52c51c61a88cd3357ded1344e37468f6a7ba4e47482bcd93a2242L175-R175) [[3]](diffhunk://#diff-3f7df7509b3895b0c05f27d490e8c977b15012bb7aaf856d5a07fdf849d53a80L231-R231)

*Kanban Board:*
- `NoResponse` receives its own column after `Rejected`, visually separated to indicate it's outside the normal application flow, and is styled with an amber/muted orange background. [[1]](diffhunk://#diff-b23b2f039bc2f44c07a74105a37a628cc94e677fc1b129cf2c92e63ebfaab489R23) [[2]](diffhunk://#diff-b23b2f039bc2f44c07a74105a37a628cc94e677fc1b129cf2c92e63ebfaab489L98-R111)

*Status Display and Sorting:*
- `StatusBadge` component displays "No Response" with a distinct amber/orange style, and all status labels are formatted using display overrides for consistency. [[1]](diffhunk://#diff-8e19ca28e19a5e57b8b83fa74f7605f467c5823538483f38afa669fc5d4d3ef9R5) [[2]](diffhunk://#diff-8e19ca28e19a5e57b8b83fa74f7605f467c5823538483f38afa669fc5d4d3ef9R33-R42) [[3]](diffhunk://#diff-55d9f28f373410bdc780d22531e5e56eb80c51b49254bbe20d59e2610256ca44R48)
- Updated job status ordering and enum definitions to include `NoResponse`. [[1]](diffhunk://#diff-ef9aa86bc466dcbabe882e6b6f7ca46c9d879b3c650ef310c1f85dd0263ee3afR31) [[2]](diffhunk://#diff-55d9f28f373410bdc780d22531e5e56eb80c51b49254bbe20d59e2610256ca44L10-R11)

**Documentation:**
- Added a new markdown file documenting the design and implementation decisions for the "No Response" status.