### PR TITLE
Feat/no response status

### DIFF
--- a/docs/plans/kanban-board.md
+++ b/docs/plans/kanban-board.md
@@ -51,27 +51,28 @@ Grep target for future refactor: `[dnd-kit-legacy]`
 | 2 | Add viewMode toggle to JobPage; render JobTable or KanbanBoard as siblings | Done |
 | 3 | Create KanbanBoard component (layout) | Done |
 | 4 | Add drag-and-drop + status patch on drop | Done |
+| 5 | DragOverlay refactor | Done |
 
 ---
 
 ## Known Issues
 
-| Issue | Root Cause | Plan |
+| Issue | Root Cause | Fix |
 |---|---|---|
-| Dragged card can scroll beyond board bounds | `restrictToScrollContainer` modifier clamps to scroll content height, not visible viewport; dnd-kit auto-scroll moves the page so the boundary shifts | Fix via `DragOverlay` refactor |
-| Drag animation not smooth | `useDraggable` transforms the original element in-place; no easing, no shadow, no scale | Fix via `DragOverlay` refactor — overlay renders a styled clone |
+| Dragged card escaped board bounds | `restrictToScrollContainer` clamps to scroll content height; auto-scroll shifted the boundary | `DragOverlay` portal on `<body>` — outside all containers; `restrictToScrollContainer` removed |
+| Drag animation not smooth | `useDraggable` transforms the original element in-place; no easing, no shadow | `DragOverlay` renders `KanbanCardPreview` clone with `shadow-lg`; original card fades via `isDragging` / `isBeingDragged` |
 
 ### DragOverlay Refactor
 
-`DragOverlay` renders the dragging card as a portal on `<body>`, outside the board DOM entirely. The original card becomes a transparent placeholder. This solves both issues: the overlay is never clipped by any container, and it can have its own transition/shadow styles.
+`DragOverlay` renders the dragging card as a portal on `<body>`, outside the board DOM entirely. The original card becomes a faded placeholder. This solves both issues: the overlay is never clipped by any container, and it carries its own shadow styles.
 
 | Change | Detail |
 |---|---|
-| `onDragStart` | Set `activeJob` state to the dragged job |
-| `onDragEnd` | Clear `activeJob`; patch status as before |
-| `DragOverlay` | Renders a `KanbanCard` clone for `activeJob`; add `transition` + `boxShadow` for smoothness |
-| Original card | Show as semi-transparent placeholder while `isDragging` |
-| `restrictToScrollContainer` modifier | Can be removed — portal overlay is not affected by scroll container bounds |
+| `onDragStart` | Sets `activeJob` + `draggingId` state |
+| `onDragEnd` | Clears `activeJob`; clears `draggingId` via `onSettled` after mutation settles |
+| `DragOverlay` | Renders `KanbanCardPreview` clone with `shadow-lg` + `cursor-grabbing`; `dropAnimation={null}` |
+| Original card | `opacity-50` while `isDragging`; `opacity-0` while `isBeingDragged` after drop |
+| `restrictToScrollContainer` | Removed — portal overlay unaffected by scroll container bounds |
 
 ---
 

--- a/docs/plans/kanban-board.md
+++ b/docs/plans/kanban-board.md
@@ -54,6 +54,27 @@ Grep target for future refactor: `[dnd-kit-legacy]`
 
 ---
 
+## Known Issues
+
+| Issue | Root Cause | Plan |
+|---|---|---|
+| Dragged card can scroll beyond board bounds | `restrictToScrollContainer` modifier clamps to scroll content height, not visible viewport; dnd-kit auto-scroll moves the page so the boundary shifts | Fix via `DragOverlay` refactor |
+| Drag animation not smooth | `useDraggable` transforms the original element in-place; no easing, no shadow, no scale | Fix via `DragOverlay` refactor — overlay renders a styled clone |
+
+### DragOverlay Refactor
+
+`DragOverlay` renders the dragging card as a portal on `<body>`, outside the board DOM entirely. The original card becomes a transparent placeholder. This solves both issues: the overlay is never clipped by any container, and it can have its own transition/shadow styles.
+
+| Change | Detail |
+|---|---|
+| `onDragStart` | Set `activeJob` state to the dragged job |
+| `onDragEnd` | Clear `activeJob`; patch status as before |
+| `DragOverlay` | Renders a `KanbanCard` clone for `activeJob`; add `transition` + `boxShadow` for smoothness |
+| Original card | Show as semi-transparent placeholder while `isDragging` |
+| `restrictToScrollContainer` modifier | Can be removed — portal overlay is not affected by scroll container bounds |
+
+---
+
 ## Dependencies
 
 ### @dnd-kit/core

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -202,6 +202,7 @@ All planned steps complete. See `docs/Demo and Auth Features Plan.md` for full d
 | Customizable table columns | `Preferences` JSON on user; column toggle UI in toolbar |
 | Job table tabs | Active / Closing Soon / All / Rejected; frontend-only filtering |
 | Kanban board view | `@dnd-kit`; drag card patches job status via PATCH |
+| Kanban DragOverlay refactor | `DragOverlay` portal; `KanbanCardPreview` clone; `draggingId` state for clean post-drop transition |
 | AI access admin | `Admin` + `AiUser` roles; `AdminController`; `/admin` page |
 | Auto-fill parsing | `ParseListingDialog`; Claude Haiku; `POST /api/jobs/parse`; 2/min rate limit |
 | RDS maintenance window | EventBridge stops DB 00:00–08:00 AEST; backend 503 on `DbException`; frontend `MaintenanceError` with time-aware message |
@@ -212,7 +213,6 @@ All planned steps complete. See `docs/Demo and Auth Features Plan.md` for full d
 
 | Plan | Item | Status |
 |---|---|---|
-| Kanban DragOverlay refactor | Drag card escapes board on auto-scroll; animation not smooth; fix requires `DragOverlay` portal approach | In Progress |
 | Dashboard / Analytics | Funnel, response rate, weekly chart, stale jobs, upcoming interviews | Pending |
 | Job analysis | `UserProfile` table + 5 AI analysis endpoints + detail page UI | Pending |
 | Company verification integration | Wire `GET /verify` into job create/edit UI; see `docs/company-verification-api-reference.md` | Pending |

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -212,6 +212,7 @@ All planned steps complete. See `docs/Demo and Auth Features Plan.md` for full d
 
 | Plan | Item | Status |
 |---|---|---|
+| Kanban DragOverlay refactor | Drag card escapes board on auto-scroll; animation not smooth; fix requires `DragOverlay` portal approach | In Progress |
 | Dashboard / Analytics | Funnel, response rate, weekly chart, stale jobs, upcoming interviews | Pending |
 | Job analysis | `UserProfile` table + 5 AI analysis endpoints + detail page UI | Pending |
 | Company verification integration | Wire `GET /verify` into job create/edit UI; see `docs/company-verification-api-reference.md` | Pending |

--- a/job-tracker-ui/src/components/KanbanBoard.tsx
+++ b/job-tracker-ui/src/components/KanbanBoard.tsx
@@ -24,33 +24,6 @@ const COLUMN_BG: Record<JobStatus, string> = {
   NoResponse: ["bg-orange-50/70", "dark:bg-orange-900/20"].join(" "),
 }
 
-// Mirrors @dnd-kit/modifiers restrictToFirstScrollableAncestor, inlined to avoid adding the package.
-// Raw dnd-kit transforms are unconstrained; this clamps x/y so the card stays inside the overflow-x-auto container.
-// Source: https://github.com/clauderic/dnd-kit/blob/master/packages/modifiers/src/restrictToFirstScrollableAncestor.ts
-// https://github.com/clauderic/dnd-kit/blob/master/packages/modifiers/src/utilities/restrictToBoundingRect.ts
-const restrictToScrollContainer: Modifier = ({
-  draggingNodeRect,
-  transform,
-  scrollableAncestorRects
-}) => {
-  const containerRect = scrollableAncestorRects[0]
-  if (!draggingNodeRect || !containerRect) return transform
-
-  const value = { ...transform }
-
-  if (draggingNodeRect.top + transform.y <= containerRect.top)
-    value.y = containerRect.top - draggingNodeRect.top
-  else if (draggingNodeRect.bottom + transform.y >= containerRect.top + containerRect.height)
-    value.y = containerRect.top + containerRect.height - draggingNodeRect.bottom
-
-  if (draggingNodeRect.left + transform.x <= containerRect.left)
-    value.x = containerRect.left - draggingNodeRect.left
-  else if (draggingNodeRect.right + transform.x >= containerRect.left + containerRect.width)
-    value.x = containerRect.left + containerRect.width - draggingNodeRect.right
-
-  return value
-}
-
 function KanbanCard({ job }: { job: Job }) {
   const navigate = useNavigate()
   const { setNodeRef, listeners, attributes, transform, isDragging } = useDraggable({
@@ -109,6 +82,32 @@ export function KanbanBoard() {
   const { data: jobs, isPending, isError, error } = useJobs()
   const { mutate: patchJob } = usePatchJob()
   const sensors = useSensors(useSensor(PointerSensor))
+  const scrollRef = useRef<HTMLDivElement>(null)
+
+  // Reads live rect + scroll from the ref on every pointer move — avoids the
+  // viewport-clipping issue of scrollableAncestorRects[0].getBoundingClientRect().
+  const restrictToContainer = useCallback<Modifier>(({ draggingNodeRect, transform }) => {
+    const el = scrollRef.current
+    if (!draggingNodeRect || !el) return transform
+
+    const rect = el.getBoundingClientRect()
+    const value = { ...transform }
+
+    const contentLeft  = rect.left - el.scrollLeft
+    const contentRight = rect.left + el.scrollWidth - el.scrollLeft
+
+    if (draggingNodeRect.left + transform.x <= contentLeft)
+      value.x = contentLeft - draggingNodeRect.left
+    else if (draggingNodeRect.right + transform.x >= contentRight)
+      value.x = contentRight - draggingNodeRect.right
+
+    if (draggingNodeRect.top + transform.y <= rect.top)
+      value.y = rect.top - draggingNodeRect.top
+    else if (draggingNodeRect.bottom + transform.y >= rect.top + rect.height)
+      value.y = rect.top + rect.height - draggingNodeRect.bottom
+
+    return value
+  }, [])
 
   function handleDragEnd(event: DragEndEvent) {
     const { active, over } = event
@@ -121,8 +120,8 @@ export function KanbanBoard() {
   if (isError) return <p>{error instanceof MaintenanceError ? error.message : 'Something went wrong.'}</p>
 
   return (
-    <DndContext sensors={sensors} modifiers={[restrictToScrollContainer]} onDragEnd={handleDragEnd}>
-      <div className="overflow-x-auto">
+    <DndContext sensors={sensors} modifiers={[restrictToContainer]} onDragEnd={handleDragEnd}>
+      <div ref={scrollRef} className="overflow-x-auto">
         <div className="flex gap-4 min-w-max pb-4">
           {COLUMNS.filter((s) => s !== JobStatus.NoResponse).map((status) => (
             <KanbanColumn

--- a/job-tracker-ui/src/components/KanbanBoard.tsx
+++ b/job-tracker-ui/src/components/KanbanBoard.tsx
@@ -62,19 +62,14 @@ function KanbanCardPreview({ job }: { job: Job }) {
 
 function KanbanCard({ job }: { job: Job }) {
   const navigate = useNavigate()
-  const { setNodeRef, listeners, attributes, transform, isDragging } = useDraggable({
+  const { setNodeRef, listeners, attributes, isDragging } = useDraggable({
     id: job.id,
     data: { status: job.status },
   })
 
-  const style = transform
-    ? { transform: `translate3d(${transform.x}px, ${transform.y}px, 0)` }
-    : undefined
-
   return (
     <div
       ref={setNodeRef}
-      style={style}
       {...listeners}
       {...attributes}
       onClick={() => navigate(`/jobs/${job.id}`)}

--- a/job-tracker-ui/src/components/KanbanBoard.tsx
+++ b/job-tracker-ui/src/components/KanbanBoard.tsx
@@ -125,7 +125,7 @@ export function KanbanBoard() {
   if (isError) return <p>{error instanceof MaintenanceError ? error.message : 'Something went wrong.'}</p>
 
   return (
-    <DndContext sensors={sensors} modifiers={[restrictToScrollContainer]} onDragEnd={handleDragEnd}>
+    <DndContext sensors={sensors} modifiers={[restrictToScrollContainer]} onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
       <div className="overflow-x-auto">
         <div className="flex gap-4 min-w-max pb-4">
           {COLUMNS.filter((s) => s !== JobStatus.NoResponse).map((status) => (

--- a/job-tracker-ui/src/components/KanbanBoard.tsx
+++ b/job-tracker-ui/src/components/KanbanBoard.tsx
@@ -108,12 +108,13 @@ export function KanbanBoard() {
   const [activeJob, setActiveJob] = useState<Job | null>(null)
 
   function handleDragStart(event: DragStartEvent) {
-    // DragOverlay renders a full card clone, so we need the Job object not just the id.
-    const job = jobs.find((j) => j.id === Number(event.active.id))
+    // DragOverlay renders a full card clone, so we need the Job object.
+    const job = jobs?.find((j) => j.id === Number(event.active.id))
     if (job) setActiveJob(job)
   }
 
   function handleDragEnd(event: DragEndEvent) {
+    setActiveJob(null)
     const { active, over } = event
     // Skip if dropped outside a column or back onto its own column.
     if (!over || active.data.current?.status === over.id) return

--- a/job-tracker-ui/src/components/KanbanBoard.tsx
+++ b/job-tracker-ui/src/components/KanbanBoard.tsx
@@ -152,6 +152,17 @@ export function KanbanBoard() {
           />
         </div>
       </div>
+      <DragOverlay>
+        {activeJob ? (
+          <div className={cn(
+            "bg-card border border-border rounded-md p-3 cursor-grab",
+            "hover:shadow-sm dark:hover:border-white/20",
+            "transition-shadow transition-colors",
+          )}>
+            <KanbanCardPreview job={activeJob} />
+          </div>
+        ) : null}
+      </DragOverlay>
     </DndContext>
   )
 }

--- a/job-tracker-ui/src/components/KanbanBoard.tsx
+++ b/job-tracker-ui/src/components/KanbanBoard.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react'
 import { DndContext, DragOverlay, PointerSensor, useDraggable, useDroppable, useSensor, useSensors } from '@dnd-kit/core'
-import type { DragEndEvent, DragStartEvent } from '@dnd-kit/core'
+import type { DragEndEvent, DragStartEvent, Modifier } from '@dnd-kit/core'
 import { useNavigate } from 'react-router'
 import { useJobs, usePatchJob } from '@/hooks/jobQuery'
 import { MaintenanceError } from '@/lib/api'
@@ -24,6 +24,26 @@ const COLUMN_BG: Record<JobStatus, string> = {
   NoResponse: ["bg-orange-50/70", "dark:bg-orange-900/20"].join(" "),
 }
 
+// Mirrors @dnd-kit/modifiers restrictToWindowEdges, inlined to avoid adding the package.
+// DragOverlay portal is unconstrained; this clamps x/y so the overlay stays within the viewport.
+// Source: https://github.com/clauderic/dnd-kit/blob/master/packages/modifiers/src/restrictToWindowEdges.ts
+const restrictToWindowEdges: Modifier = ({ draggingNodeRect, transform, windowRect }) => {
+  if (!draggingNodeRect || !windowRect) return transform
+
+  const value = { ...transform }
+
+  if (draggingNodeRect.top + transform.y <= windowRect.top)
+    value.y = windowRect.top - draggingNodeRect.top
+  else if (draggingNodeRect.bottom + transform.y >= windowRect.top + windowRect.height)
+    value.y = windowRect.top + windowRect.height - draggingNodeRect.bottom
+
+  if (draggingNodeRect.left + transform.x <= windowRect.left)
+    value.x = windowRect.left - draggingNodeRect.left
+  else if (draggingNodeRect.right + transform.x >= windowRect.left + windowRect.width)
+    value.x = windowRect.left + windowRect.width - draggingNodeRect.right
+
+  return value
+}
 
 // Renders card visuals only, used by DragOverlay as the dragging clone.
 function KanbanCardPreview({ job }: { job: Job }) {
@@ -116,7 +136,7 @@ export function KanbanBoard() {
   if (isError) return <p>{error instanceof MaintenanceError ? error.message : 'Something went wrong.'}</p>
 
   return (
-    <DndContext sensors={sensors} onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
+    <DndContext sensors={sensors} modifiers={[restrictToWindowEdges]} onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
       <div className="overflow-x-auto">
         <div className="flex gap-4 min-w-max pb-4">
           {COLUMNS.filter((s) => s !== JobStatus.NoResponse).map((status) => (

--- a/job-tracker-ui/src/components/KanbanBoard.tsx
+++ b/job-tracker-ui/src/components/KanbanBoard.tsx
@@ -2,7 +2,6 @@
 
 import { DndContext, PointerSensor, useDraggable, useDroppable, useSensor, useSensors } from '@dnd-kit/core'
 import type { DragEndEvent, Modifier } from '@dnd-kit/core'
-import { useRef, useCallback } from 'react'
 import { useNavigate } from 'react-router'
 import { useJobs, usePatchJob } from '@/hooks/jobQuery'
 import { MaintenanceError } from '@/lib/api'
@@ -22,6 +21,29 @@ const COLUMN_BG: Record<JobStatus, string> = {
   Offered:   ["bg-green-50/70",  "dark:bg-green-900/20"].join(" "),
   Rejected:   ["bg-red-50/70",    "dark:bg-red-900/20"].join(" "),
   NoResponse: ["bg-orange-50/70", "dark:bg-orange-900/20"].join(" "),
+}
+
+// Mirrors @dnd-kit/modifiers restrictToFirstScrollableAncestor, inlined to avoid adding the package.
+// Raw dnd-kit transforms are unconstrained; this clamps x/y so the card stays inside the overflow-x-auto container.
+// Source: https://github.com/clauderic/dnd-kit/blob/master/packages/modifiers/src/restrictToFirstScrollableAncestor.ts
+// https://github.com/clauderic/dnd-kit/blob/master/packages/modifiers/src/utilities/restrictToBoundingRect.ts
+const restrictToScrollContainer: Modifier = ({ draggingNodeRect, transform, scrollableAncestorRects }) => {
+  const containerRect = scrollableAncestorRects[0]
+  if (!draggingNodeRect || !containerRect) return transform
+
+  const value = { ...transform }
+
+  if (draggingNodeRect.top + transform.y <= containerRect.top)
+    value.y = containerRect.top - draggingNodeRect.top
+  else if (draggingNodeRect.bottom + transform.y >= containerRect.top + containerRect.height)
+    value.y = containerRect.top + containerRect.height - draggingNodeRect.bottom
+
+  if (draggingNodeRect.left + transform.x <= containerRect.left)
+    value.x = containerRect.left - draggingNodeRect.left
+  else if (draggingNodeRect.right + transform.x >= containerRect.left + containerRect.width)
+    value.x = containerRect.left + containerRect.width - draggingNodeRect.right
+
+  return value
 }
 
 function KanbanCard({ job }: { job: Job }) {
@@ -82,32 +104,6 @@ export function KanbanBoard() {
   const { data: jobs, isPending, isError, error } = useJobs()
   const { mutate: patchJob } = usePatchJob()
   const sensors = useSensors(useSensor(PointerSensor))
-  const scrollRef = useRef<HTMLDivElement>(null)
-
-  // Reads live rect + scroll from the ref on every pointer move — avoids the
-  // viewport-clipping issue of scrollableAncestorRects[0].getBoundingClientRect().
-  const restrictToContainer = useCallback<Modifier>(({ draggingNodeRect, transform }) => {
-    const el = scrollRef.current
-    if (!draggingNodeRect || !el) return transform
-
-    const rect = el.getBoundingClientRect()
-    const value = { ...transform }
-
-    const contentLeft  = rect.left - el.scrollLeft
-    const contentRight = rect.left + el.scrollWidth - el.scrollLeft
-
-    if (draggingNodeRect.left + transform.x <= contentLeft)
-      value.x = contentLeft - draggingNodeRect.left
-    else if (draggingNodeRect.right + transform.x >= contentRight)
-      value.x = contentRight - draggingNodeRect.right
-
-    if (draggingNodeRect.top + transform.y <= rect.top)
-      value.y = rect.top - draggingNodeRect.top
-    else if (draggingNodeRect.bottom + transform.y >= rect.top + rect.height)
-      value.y = rect.top + rect.height - draggingNodeRect.bottom
-
-    return value
-  }, [])
 
   function handleDragEnd(event: DragEndEvent) {
     const { active, over } = event
@@ -120,8 +116,8 @@ export function KanbanBoard() {
   if (isError) return <p>{error instanceof MaintenanceError ? error.message : 'Something went wrong.'}</p>
 
   return (
-    <DndContext sensors={sensors} modifiers={[restrictToContainer]} onDragEnd={handleDragEnd}>
-      <div ref={scrollRef} className="overflow-x-auto">
+    <DndContext sensors={sensors} modifiers={[restrictToScrollContainer]} onDragEnd={handleDragEnd}>
+      <div className="overflow-x-auto">
         <div className="flex gap-4 min-w-max pb-4">
           {COLUMNS.filter((s) => s !== JobStatus.NoResponse).map((status) => (
             <KanbanColumn

--- a/job-tracker-ui/src/components/KanbanBoard.tsx
+++ b/job-tracker-ui/src/components/KanbanBoard.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react'
 import { DndContext, DragOverlay, PointerSensor, useDraggable, useDroppable, useSensor, useSensors } from '@dnd-kit/core'
-import type { DragEndEvent, DragStartEvent, Modifier } from '@dnd-kit/core'
+import type { DragEndEvent, DragStartEvent } from '@dnd-kit/core'
 import { useNavigate } from 'react-router'
 import { useJobs, usePatchJob } from '@/hooks/jobQuery'
 import { MaintenanceError } from '@/lib/api'
@@ -24,28 +24,6 @@ const COLUMN_BG: Record<JobStatus, string> = {
   NoResponse: ["bg-orange-50/70", "dark:bg-orange-900/20"].join(" "),
 }
 
-// Mirrors @dnd-kit/modifiers restrictToFirstScrollableAncestor, inlined to avoid adding the package.
-// Raw dnd-kit transforms are unconstrained; this clamps x/y so the card stays inside the overflow-x-auto container.
-// Source: https://github.com/clauderic/dnd-kit/blob/master/packages/modifiers/src/restrictToFirstScrollableAncestor.ts
-// https://github.com/clauderic/dnd-kit/blob/master/packages/modifiers/src/utilities/restrictToBoundingRect.ts
-const restrictToScrollContainer: Modifier = ({ draggingNodeRect, transform, scrollableAncestorRects }) => {
-  const containerRect = scrollableAncestorRects[0]
-  if (!draggingNodeRect || !containerRect) return transform
-
-  const value = { ...transform }
-
-  if (draggingNodeRect.top + transform.y <= containerRect.top)
-    value.y = containerRect.top - draggingNodeRect.top
-  else if (draggingNodeRect.bottom + transform.y >= containerRect.top + containerRect.height)
-    value.y = containerRect.top + containerRect.height - draggingNodeRect.bottom
-
-  if (draggingNodeRect.left + transform.x <= containerRect.left)
-    value.x = containerRect.left - draggingNodeRect.left
-  else if (draggingNodeRect.right + transform.x >= containerRect.left + containerRect.width)
-    value.x = containerRect.left + containerRect.width - draggingNodeRect.right
-
-  return value
-}
 
 // Renders card visuals only, used by DragOverlay as the dragging clone.
 function KanbanCardPreview({ job }: { job: Job }) {

--- a/job-tracker-ui/src/components/KanbanBoard.tsx
+++ b/job-tracker-ui/src/components/KanbanBoard.tsx
@@ -107,6 +107,12 @@ export function KanbanBoard() {
   const sensors = useSensors(useSensor(PointerSensor))
   const [activeJob, setActiveJob] = useState<Job | null>(null)
 
+  function handleDragStart(event: DragStartEvent) {
+    // DragOverlay renders a full card clone, so we need the Job object not just the id.
+    const job = jobs.find((j) => j.id === Number(event.active.id))
+    if (job) setActiveJob(job)
+  }
+
   function handleDragEnd(event: DragEndEvent) {
     const { active, over } = event
     // Skip if dropped outside a column or back onto its own column.

--- a/job-tracker-ui/src/components/KanbanBoard.tsx
+++ b/job-tracker-ui/src/components/KanbanBoard.tsx
@@ -38,7 +38,7 @@ function KanbanCardPreview({ job }: { job: Job }) {
   )
 }
 
-function KanbanCard({ job }: { job: Job }) {
+function KanbanCard({ job, isBeingDragged }: { job: Job; isBeingDragged: boolean }) {
   const navigate = useNavigate()
   const { setNodeRef, listeners, attributes, isDragging } = useDraggable({
     id: job.id,
@@ -55,7 +55,8 @@ function KanbanCard({ job }: { job: Job }) {
         "bg-card border border-border rounded-md p-3 cursor-grab",
         "hover:shadow-sm dark:hover:border-white/20",
         "transition-shadow transition-colors",
-        isDragging && "opacity-50"
+        isDragging && "opacity-50",
+        !isDragging && isBeingDragged && "opacity-0",
       )}
     >
       <KanbanCardPreview job={job} />
@@ -63,7 +64,7 @@ function KanbanCard({ job }: { job: Job }) {
   )
 }
 
-function KanbanColumn({ status, jobs }: { status: JobStatus; jobs: Job[] }) {
+function KanbanColumn({ status, jobs, draggingId }: { status: JobStatus; jobs: Job[]; draggingId: number | null }) {
   const { setNodeRef, isOver } = useDroppable({ id: status })
 
   return (
@@ -76,7 +77,7 @@ function KanbanColumn({ status, jobs }: { status: JobStatus; jobs: Job[] }) {
         className={`${COLUMN_BG[status]} rounded-md p-2 flex flex-col gap-2 min-h-[120px] flex-1 ${isOver ? 'ring-2 ring-inset ring-primary/40' : ''}`}
       >
         {jobs.map((job) => (
-          <KanbanCard key={job.id} job={job} />
+          <KanbanCard key={job.id} job={job} isBeingDragged={job.id === draggingId} />
         ))}
       </div>
     </div>
@@ -88,19 +89,27 @@ export function KanbanBoard() {
   const { mutate: patchJob } = usePatchJob()
   const sensors = useSensors(useSensor(PointerSensor))
   const [activeJob, setActiveJob] = useState<Job | null>(null)
+  const [draggingId, setDraggingId] = useState<number | null>(null)
 
   function handleDragStart(event: DragStartEvent) {
     // DragOverlay renders a full card clone, so we need the Job object.
     const job = jobs?.find((j) => j.id === Number(event.active.id))
     if (job) setActiveJob(job)
+    setDraggingId(Number(event.active.id))
   }
 
   function handleDragEnd(event: DragEndEvent) {
     setActiveJob(null)
     const { active, over } = event
     // Skip if dropped outside a column or back onto its own column.
-    if (!over || active.data.current?.status === over.id) return
-    patchJob({ id: Number(active.id), operations: [{ op: 'replace', path: '/status', value: over.id as JobStatus }] })
+    if (!over || active.data.current?.status === over.id) {
+      setDraggingId(null)
+      return
+    }
+    patchJob(
+      { id: Number(active.id), operations: [{ op: 'replace', path: '/status', value: over.id as JobStatus }] },
+      { onSettled: () => setDraggingId(null) }
+    )
   }
 
   if (isPending) return <p>Loading...</p>
@@ -115,6 +124,7 @@ export function KanbanBoard() {
               key={status}
               status={status}
               jobs={jobs.filter((j) => j.status === status)}
+              draggingId={draggingId}
             />
           ))}
           {/* NoResponse is outside the normal application flow */}
@@ -122,10 +132,11 @@ export function KanbanBoard() {
           <KanbanColumn
             status={JobStatus.NoResponse}
             jobs={jobs.filter((j) => j.status === JobStatus.NoResponse)}
+            draggingId={draggingId}
           />
         </div>
       </div>
-      <DragOverlay>
+      <DragOverlay dropAnimation={null}>
         {activeJob ? (
           <div className={cn(
             "bg-card border border-border rounded-md p-3",

--- a/job-tracker-ui/src/components/KanbanBoard.tsx
+++ b/job-tracker-ui/src/components/KanbanBoard.tsx
@@ -85,11 +85,7 @@ function KanbanCard({ job }: { job: Job }) {
         isDragging && "opacity-50"
       )}
     >
-      <p className="font-medium text-sm truncate">{job.company}</p>
-      <p className="text-xs text-muted-foreground truncate">{job.role}</p>
-      <div className="mt-2">
-        <PriorityDot priority={job.priority} dotSize="w-2 h-2" />
-      </div>
+      <KanbanCardPreview job={job} />
     </div>
   )
 }

--- a/job-tracker-ui/src/components/KanbanBoard.tsx
+++ b/job-tracker-ui/src/components/KanbanBoard.tsx
@@ -128,9 +128,8 @@ export function KanbanBoard() {
       <DragOverlay>
         {activeJob ? (
           <div className={cn(
-            "bg-card border border-border rounded-md p-3 cursor-grab",
-            "hover:shadow-sm dark:hover:border-white/20",
-            "transition-shadow transition-colors",
+            "bg-card border border-border rounded-md p-3",
+            "cursor-grabbing shadow-lg",
           )}>
             <KanbanCardPreview job={activeJob} />
           </div>

--- a/job-tracker-ui/src/components/KanbanBoard.tsx
+++ b/job-tracker-ui/src/components/KanbanBoard.tsx
@@ -1,7 +1,8 @@
 // [dnd-kit-legacy] migrate to @dnd-kit/react when v1.0 is stable
 
-import { DndContext, PointerSensor, useDraggable, useDroppable, useSensor, useSensors } from '@dnd-kit/core'
-import type { DragEndEvent, Modifier } from '@dnd-kit/core'
+import { useState } from 'react'
+import { DndContext, DragOverlay, PointerSensor, useDraggable, useDroppable, useSensor, useSensors } from '@dnd-kit/core'
+import type { DragEndEvent, DragStartEvent, Modifier } from '@dnd-kit/core'
 import { useNavigate } from 'react-router'
 import { useJobs, usePatchJob } from '@/hooks/jobQuery'
 import { MaintenanceError } from '@/lib/api'
@@ -104,6 +105,7 @@ export function KanbanBoard() {
   const { data: jobs, isPending, isError, error } = useJobs()
   const { mutate: patchJob } = usePatchJob()
   const sensors = useSensors(useSensor(PointerSensor))
+  const [activeJob, setActiveJob] = useState<Job | null>(null)
 
   function handleDragEnd(event: DragEndEvent) {
     const { active, over } = event

--- a/job-tracker-ui/src/components/KanbanBoard.tsx
+++ b/job-tracker-ui/src/components/KanbanBoard.tsx
@@ -129,7 +129,7 @@ export function KanbanBoard() {
   if (isError) return <p>{error instanceof MaintenanceError ? error.message : 'Something went wrong.'}</p>
 
   return (
-    <DndContext sensors={sensors} modifiers={[restrictToScrollContainer]} onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
+    <DndContext sensors={sensors} onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
       <div className="overflow-x-auto">
         <div className="flex gap-4 min-w-max pb-4">
           {COLUMNS.filter((s) => s !== JobStatus.NoResponse).map((status) => (

--- a/job-tracker-ui/src/components/KanbanBoard.tsx
+++ b/job-tracker-ui/src/components/KanbanBoard.tsx
@@ -1,7 +1,7 @@
 // [dnd-kit-legacy] migrate to @dnd-kit/react when v1.0 is stable
 
 import { DndContext, PointerSensor, useDraggable, useDroppable, useSensor, useSensors } from '@dnd-kit/core'
-import type { DragEndEvent } from '@dnd-kit/core'
+import type { DragEndEvent, Modifier } from '@dnd-kit/core'
 import { useNavigate } from 'react-router'
 import { useJobs, usePatchJob } from '@/hooks/jobQuery'
 import { MaintenanceError } from '@/lib/api'
@@ -21,6 +21,33 @@ const COLUMN_BG: Record<JobStatus, string> = {
   Offered:   ["bg-green-50/70",  "dark:bg-green-900/20"].join(" "),
   Rejected:   ["bg-red-50/70",    "dark:bg-red-900/20"].join(" "),
   NoResponse: ["bg-orange-50/70", "dark:bg-orange-900/20"].join(" "),
+}
+
+// Mirrors @dnd-kit/modifiers restrictToFirstScrollableAncestor, inlined to avoid adding the package.
+// Raw dnd-kit transforms are unconstrained; this clamps x/y so the card stays inside the overflow-x-auto container.
+// Source: https://github.com/clauderic/dnd-kit/blob/master/packages/modifiers/src/restrictToFirstScrollableAncestor.ts
+// https://github.com/clauderic/dnd-kit/blob/master/packages/modifiers/src/utilities/restrictToBoundingRect.ts
+const restrictToScrollContainer: Modifier = ({
+  draggingNodeRect,
+  transform,
+  scrollableAncestorRects
+}) => {
+  const containerRect = scrollableAncestorRects[0]
+  if (!draggingNodeRect || !containerRect) return transform
+
+  const value = { ...transform }
+
+  if (draggingNodeRect.top + transform.y <= containerRect.top)
+    value.y = containerRect.top - draggingNodeRect.top
+  else if (draggingNodeRect.bottom + transform.y >= containerRect.top + containerRect.height)
+    value.y = containerRect.top + containerRect.height - draggingNodeRect.bottom
+
+  if (draggingNodeRect.left + transform.x <= containerRect.left)
+    value.x = containerRect.left - draggingNodeRect.left
+  else if (draggingNodeRect.right + transform.x >= containerRect.left + containerRect.width)
+    value.x = containerRect.left + containerRect.width - draggingNodeRect.right
+
+  return value
 }
 
 function KanbanCard({ job }: { job: Job }) {
@@ -93,7 +120,7 @@ export function KanbanBoard() {
   if (isError) return <p>{error instanceof MaintenanceError ? error.message : 'Something went wrong.'}</p>
 
   return (
-    <DndContext sensors={sensors} onDragEnd={handleDragEnd}>
+    <DndContext sensors={sensors} modifiers={[restrictToScrollContainer]} onDragEnd={handleDragEnd}>
       <div className="overflow-x-auto">
         <div className="flex gap-4 min-w-max pb-4">
           {COLUMNS.filter((s) => s !== JobStatus.NoResponse).map((status) => (

--- a/job-tracker-ui/src/components/KanbanBoard.tsx
+++ b/job-tracker-ui/src/components/KanbanBoard.tsx
@@ -47,6 +47,19 @@ const restrictToScrollContainer: Modifier = ({ draggingNodeRect, transform, scro
   return value
 }
 
+// Renders card visuals only, used by DragOverlay as the dragging clone.
+function KanbanCardPreview({ job }: { job: Job }) {
+  return (
+    <>
+      <p className="font-medium text-sm truncate">{job.company}</p>
+      <p className="text-xs text-muted-foreground truncate">{job.role}</p>
+      <div className="mt-2">
+        <PriorityDot priority={job.priority} dotSize="w-2 h-2" />
+      </div>
+    </>
+  )
+}
+
 function KanbanCard({ job }: { job: Job }) {
   const navigate = useNavigate()
   const { setNodeRef, listeners, attributes, transform, isDragging } = useDraggable({

--- a/job-tracker-ui/src/components/KanbanBoard.tsx
+++ b/job-tracker-ui/src/components/KanbanBoard.tsx
@@ -2,6 +2,7 @@
 
 import { DndContext, PointerSensor, useDraggable, useDroppable, useSensor, useSensors } from '@dnd-kit/core'
 import type { DragEndEvent, Modifier } from '@dnd-kit/core'
+import { useRef, useCallback } from 'react'
 import { useNavigate } from 'react-router'
 import { useJobs, usePatchJob } from '@/hooks/jobQuery'
 import { MaintenanceError } from '@/lib/api'
@@ -94,7 +95,7 @@ function KanbanColumn({ status, jobs }: { status: JobStatus; jobs: Job[] }) {
       </div>
       <div
         ref={setNodeRef}
-        className={`${COLUMN_BG[status]} rounded-md p-2 flex flex-col gap-2 min-h-[120px] ${isOver ? 'ring-2 ring-inset ring-primary/40' : ''}`}
+        className={`${COLUMN_BG[status]} rounded-md p-2 flex flex-col gap-2 min-h-[120px] flex-1 ${isOver ? 'ring-2 ring-inset ring-primary/40' : ''}`}
       >
         {jobs.map((job) => (
           <KanbanCard key={job.id} job={job} />


### PR DESCRIPTION
This pull request refactors the Kanban board drag-and-drop experience by introducing a `DragOverlay` portal for smoother and less constrained dragging, and improves the visual feedback during drag operations. The changes address previous issues with card clipping and animation, and clean up the code to support these improvements.

**Kanban Drag-and-Drop Refactor:**

* Added a `DragOverlay` portal that renders a clone of the dragged card on the `<body>`, ensuring it is never clipped by container bounds and allowing for custom shadow styles. The original card fades out smoothly during dragging and after drop. (`job-tracker-ui/src/components/KanbanBoard.tsx`, `docs/plans/kanban-board.md`, `docs/progress.md`) [[1]](diffhunk://#diff-b23b2f039bc2f44c07a74105a37a628cc94e677fc1b129cf2c92e63ebfaab489L3-R5) [[2]](diffhunk://#diff-b23b2f039bc2f44c07a74105a37a628cc94e677fc1b129cf2c92e63ebfaab489L26-R87) [[3]](diffhunk://#diff-b23b2f039bc2f44c07a74105a37a628cc94e677fc1b129cf2c92e63ebfaab489L70-R100) [[4]](diffhunk://#diff-b23b2f039bc2f44c07a74105a37a628cc94e677fc1b129cf2c92e63ebfaab489R111-R168) [[5]](diffhunk://#diff-9e27b4fd569516219e7fe60cb942004780d7982c9e3c756eabf8eb3a2a4aecdfR54-R75) [[6]](diffhunk://#diff-378b8e52823d637f240b08446ef15475f13745a2cabebff169eb567074cba6b3R205)

* Introduced `draggingId` and `activeJob` state to track the currently dragged card and manage transitions and overlay rendering. (`job-tracker-ui/src/components/KanbanBoard.tsx`)

**Bug Fixes and Visual Improvements:**

* Removed the `restrictToScrollContainer` modifier and added a new `restrictToWindowEdges` modifier to keep the drag overlay within the viewport, solving issues with cards escaping board bounds. (`job-tracker-ui/src/components/KanbanBoard.tsx`, `docs/plans/kanban-board.md`) [[1]](diffhunk://#diff-b23b2f039bc2f44c07a74105a37a628cc94e677fc1b129cf2c92e63ebfaab489L26-R87) [[2]](diffhunk://#diff-9e27b4fd569516219e7fe60cb942004780d7982c9e3c756eabf8eb3a2a4aecdfR54-R75)

* Improved drag animation by rendering a `KanbanCardPreview` clone with a shadow and fading the original card using `isDragging`/`isBeingDragged` states for a cleaner visual transition. (`job-tracker-ui/src/components/KanbanBoard.tsx`, `docs/plans/kanban-board.md`) [[1]](diffhunk://#diff-b23b2f039bc2f44c07a74105a37a628cc94e677fc1b129cf2c92e63ebfaab489L26-R87) [[2]](diffhunk://#diff-b23b2f039bc2f44c07a74105a37a628cc94e677fc1b129cf2c92e63ebfaab489L70-R100) [[3]](diffhunk://#diff-9e27b4fd569516219e7fe60cb942004780d7982c9e3c756eabf8eb3a2a4aecdfR54-R75)

**Documentation Updates:**

* Updated documentation in `docs/plans/kanban-board.md` and `docs/progress.md` to reflect the new drag-and-drop implementation and document known issues and their resolutions. [[1]](diffhunk://#diff-9e27b4fd569516219e7fe60cb942004780d7982c9e3c756eabf8eb3a2a4aecdfR54-R75) [[2]](diffhunk://#diff-378b8e52823d637f240b08446ef15475f13745a2cabebff169eb567074cba6b3R205)