### PR TITLE
Feat/dashboard analytics

### DIFF
--- a/docs/progress.md
+++ b/docs/progress.md
@@ -221,3 +221,4 @@ All planned steps complete. See `docs/Demo and Auth Features Plan.md` for full d
 | Job application rating API | Crowdsourced company ratings; separate product; scoring weights not finalized | Early planning |
 | Table scroll accessibility | Viewport-contained flex chain; `table-plain.tsx`; sticky `TableHeader`; see `docs/plans/table-scroll-accessibility.md` | Done |
 | Action bar layout fix | Move "Add New Job" + "Show/Hide Columns" into the view toggle row (`JobPage.tsx`) so they anchor to window edge — prevents clipping on narrow viewports; requires lifting add-job dialog trigger out of `JobTable` | Pending |
+| — | View toggle + column selector polish | `IconToggle.tsx` extracted from `JobPage`; pill shape, animated check icon, blue active state; `ColumnToggle` icon + scroll still pending | In Progress |

--- a/job-tracker-ui/src/components/IconToggle.tsx
+++ b/job-tracker-ui/src/components/IconToggle.tsx
@@ -1,5 +1,6 @@
 // Reusable icon-based toggle group for mutually exclusive view/mode switching.
 import { Check } from 'lucide-react'
+import { Fragment } from 'react'
 import type { ReactNode } from 'react'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
@@ -19,22 +20,25 @@ interface IconToggleProps<T extends string> {
 /** Renders a pill-shaped button group where exactly one option is active at a time. */
 export function IconToggle<T extends string>({ options, value, onChange }: IconToggleProps<T>) {
   return (
-    <div className="flex bg-card rounded-full p-1 shadow-sm divide-x divide-border">
-      {options.map((opt) => {
+    <div className="flex bg-card rounded-full p-1 shadow-sm">
+      {options.map((opt, i) => {
         const active = opt.value === value
         return (
-          <Button
-            key={opt.value}
-            variant={active ? 'secondary' : 'ghost'}
-            size="sm"
-            className="rounded-full"
-            onClick={() => onChange(opt.value)}
-          >
-            {/* Always rendered so button width stays fixed regardless of active state. */}
-            <Check className={cn('h-3 w-3', active ? 'visible' : 'invisible')} />
-            {opt.icon}
-            {opt.label && <span>{opt.label}</span>}
-          </Button>
+          <Fragment key={opt.value}>
+            {/* Divider between options; inset vertically so it doesn't reach the container edge. */}
+            {i > 0 && <div className="w-0.5 bg-muted-foreground/40 self-stretch" />}
+            <Button
+              variant={active ? 'secondary' : 'ghost'}
+              size="sm"
+              className="rounded-full"
+              onClick={() => onChange(opt.value)}
+            >
+              {/* Always rendered so button width stays fixed regardless of active state. */}
+              <Check className={cn('h-3 w-3', active ? 'visible' : 'invisible')} />
+              {opt.icon}
+              {opt.label && <span>{opt.label}</span>}
+            </Button>
+          </Fragment>
         )
       })}
     </div>

--- a/job-tracker-ui/src/components/IconToggle.tsx
+++ b/job-tracker-ui/src/components/IconToggle.tsx
@@ -30,10 +30,10 @@ export function IconToggle<T extends string>({ options, value, onChange }: IconT
             <Button
               variant={active ? 'secondary' : 'ghost'}
               size="sm"
-              className="rounded-full"
+              className={cn('rounded-full', active && 'bg-blue-100 text-blue-700 hover:bg-blue-200 dark:bg-blue-900/40 dark:text-blue-300 dark:hover:bg-blue-900/60')}
               onClick={() => onChange(opt.value)}
             >
-              {/* Span animates width to reveal/hide the check; overflow-hidden clips it when collapsed. */}
+              {/* Span animates width to reveal/hide the check */}
               <span className={cn(
                 'overflow-hidden transition-all duration-200',
                 active ? 'w-4 opacity-100' : 'w-0 opacity-0'

--- a/job-tracker-ui/src/components/IconToggle.tsx
+++ b/job-tracker-ui/src/components/IconToggle.tsx
@@ -25,7 +25,7 @@ export function IconToggle<T extends string>({ options, value, onChange }: IconT
         const active = opt.value === value
         return (
           <Fragment key={opt.value}>
-            {/* Divider between options; inset vertically so it doesn't reach the container edge. */}
+            {/* Divider between options */}
             {i > 0 && <div className="w-0.5 bg-muted-foreground/40 self-stretch" />}
             <Button
               variant={active ? 'secondary' : 'ghost'}
@@ -33,8 +33,13 @@ export function IconToggle<T extends string>({ options, value, onChange }: IconT
               className="rounded-full"
               onClick={() => onChange(opt.value)}
             >
-              {/* Always rendered so button width stays fixed regardless of active state. */}
-              <Check className={cn('h-3 w-3', active ? 'visible' : 'invisible')} />
+              {/* Span animates width to reveal/hide the check; overflow-hidden clips it when collapsed. */}
+              <span className={cn(
+                'overflow-hidden transition-all duration-200',
+                active ? 'w-4 opacity-100' : 'w-0 opacity-0'
+              )}>
+                <Check />
+              </span>
               {opt.icon}
               {opt.label && <span>{opt.label}</span>}
             </Button>

--- a/job-tracker-ui/src/components/IconToggle.tsx
+++ b/job-tracker-ui/src/components/IconToggle.tsx
@@ -16,10 +16,10 @@ interface IconToggleProps<T extends string> {
   onChange: (value: T) => void
 }
 
-/** Renders a rounded button group where exactly one option is active at a time. */
+/** Renders a pill-shaped button group where exactly one option is active at a time. */
 export function IconToggle<T extends string>({ options, value, onChange }: IconToggleProps<T>) {
   return (
-    <div className="flex gap-1 bg-card rounded-xl p-1 shadow-sm">
+    <div className="flex bg-card rounded-full p-1 shadow-sm divide-x divide-border">
       {options.map((opt) => {
         const active = opt.value === value
         return (
@@ -27,12 +27,13 @@ export function IconToggle<T extends string>({ options, value, onChange }: IconT
             key={opt.value}
             variant={active ? 'secondary' : 'ghost'}
             size="sm"
+            className="rounded-full"
             onClick={() => onChange(opt.value)}
           >
-            {opt.icon}
-            {opt.label && <span>{opt.label}</span>}
             {/* Always rendered so button width stays fixed regardless of active state. */}
             <Check className={cn('h-3 w-3', active ? 'visible' : 'invisible')} />
+            {opt.icon}
+            {opt.label && <span>{opt.label}</span>}
           </Button>
         )
       })}

--- a/job-tracker-ui/src/components/IconToggle.tsx
+++ b/job-tracker-ui/src/components/IconToggle.tsx
@@ -1,0 +1,41 @@
+// Reusable icon-based toggle group for mutually exclusive view/mode switching.
+import { Check } from 'lucide-react'
+import type { ReactNode } from 'react'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+
+interface ToggleOption<T extends string> {
+  value: T
+  icon: ReactNode
+  label?: string
+}
+
+interface IconToggleProps<T extends string> {
+  options: ToggleOption<T>[]
+  value: T
+  onChange: (value: T) => void
+}
+
+/** Renders a rounded button group where exactly one option is active at a time. */
+export function IconToggle<T extends string>({ options, value, onChange }: IconToggleProps<T>) {
+  return (
+    <div className="flex gap-1 bg-card rounded-xl p-1 shadow-sm">
+      {options.map((opt) => {
+        const active = opt.value === value
+        return (
+          <Button
+            key={opt.value}
+            variant={active ? 'secondary' : 'ghost'}
+            size="sm"
+            onClick={() => onChange(opt.value)}
+          >
+            {opt.icon}
+            {opt.label && <span>{opt.label}</span>}
+            {/* Always rendered so button width stays fixed regardless of active state. */}
+            <Check className={cn('h-3 w-3', active ? 'visible' : 'invisible')} />
+          </Button>
+        )
+      })}
+    </div>
+  )
+}

--- a/job-tracker-ui/src/components/JobTable.tsx
+++ b/job-tracker-ui/src/components/JobTable.tsx
@@ -308,7 +308,7 @@ export function JobTable() {
   const showControls = activeTab !== "closed";
 
   return (
-    <div className="flex flex-col gap-2 h-full">
+    <div className="flex flex-col gap-2 h-full min-w-0">
 
       {/* Page header */}
       <div className="flex items-center justify-between px-2">
@@ -325,7 +325,7 @@ export function JobTable() {
       <hr className="border-t border-border" />
 
       {/* Tab nav */}
-      <div className={cn("flex flex-col flex-1 min-h-0", TAB_STYLES[activeTab].table)}>
+      <div className={cn("flex flex-col flex-1 min-h-0 min-w-0", TAB_STYLES[activeTab].table)}>
       <Tabs value={activeTab} onValueChange={(v) => setActiveTab(v as typeof activeTab)}>
         <TabsList className="bg-card p-0 h-auto rounded-none border-b border-border w-full justify-start items-end gap-1">
           {(

--- a/job-tracker-ui/src/components/ui/tooltip.tsx
+++ b/job-tracker-ui/src/components/ui/tooltip.tsx
@@ -1,0 +1,55 @@
+import * as React from "react"
+import { Tooltip as TooltipPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function TooltipProvider({
+  delayDuration = 0,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Provider>) {
+  return (
+    <TooltipPrimitive.Provider
+      data-slot="tooltip-provider"
+      delayDuration={delayDuration}
+      {...props}
+    />
+  )
+}
+
+function Tooltip({
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Root>) {
+  return <TooltipPrimitive.Root data-slot="tooltip" {...props} />
+}
+
+function TooltipTrigger({
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
+  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />
+}
+
+function TooltipContent({
+  className,
+  sideOffset = 0,
+  children,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Content>) {
+  return (
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Content
+        data-slot="tooltip-content"
+        sideOffset={sideOffset}
+        className={cn(
+          "z-50 inline-flex w-fit max-w-xs origin-(--radix-tooltip-content-transform-origin) items-center gap-1.5 rounded-md bg-foreground px-3 py-1.5 text-xs text-background has-data-[slot=kbd]:pr-1.5 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 **:data-[slot=kbd]:relative **:data-[slot=kbd]:isolate **:data-[slot=kbd]:z-50 **:data-[slot=kbd]:rounded-sm data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        <TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px] bg-foreground fill-foreground" />
+      </TooltipPrimitive.Content>
+    </TooltipPrimitive.Portal>
+  )
+}
+
+export { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger }

--- a/job-tracker-ui/src/pages/JobPage.tsx
+++ b/job-tracker-ui/src/pages/JobPage.tsx
@@ -1,11 +1,16 @@
 import NavBar from '@/components/NavBar'
 import { JobTable } from '@/components/JobTable'
 import { KanbanBoard } from '@/components/KanbanBoard'
-import { Button } from '@/components/ui/button'
+import { IconToggle } from '@/components/IconToggle'
 import { Kanban, LayoutList } from 'lucide-react'
 import { useState } from 'react'
 
 type ViewMode = 'table' | 'kanban'
+
+const VIEW_OPTIONS = [
+  { value: 'table' as const,  icon: <LayoutList className="h-4 w-4" /> },
+  { value: 'kanban' as const, icon: <Kanban className="h-4 w-4" /> },
+]
 
 function JobPage() {
   const [viewMode, setViewMode] = useState<ViewMode>('table')
@@ -13,24 +18,8 @@ function JobPage() {
   return (
     <div className="h-screen bg-muted flex flex-col overflow-hidden">
       <NavBar />
-      {/* View toggle */}
       <div className="max-w-5xl mx-auto w-full px-4 py-2 flex justify-end">
-        <div className="flex gap-1 bg-card rounded-md p-1 shadow-sm">
-          <Button
-            variant={viewMode === 'table' ? 'secondary' : 'ghost'}
-            onClick={() => setViewMode('table')}
-          >
-            <LayoutList className="h-4 w-4" />
-            Table View
-          </Button>
-          <Button
-            variant={viewMode === 'kanban' ? 'secondary' : 'ghost'}
-            onClick={() => setViewMode('kanban')}
-          >
-            <Kanban className="h-4 w-4" />
-            Kanban View
-          </Button>
-        </div>
+        <IconToggle options={VIEW_OPTIONS} value={viewMode} onChange={setViewMode} />
       </div>
 
       <div className={`${viewMode === 'kanban' ? 'max-w-7xl px-2' : 'max-w-5xl px-4'} mx-auto w-full pb-1 flex-1 flex flex-col min-h-0 min-w-0`}>

--- a/job-tracker-ui/src/pages/JobPage.tsx
+++ b/job-tracker-ui/src/pages/JobPage.tsx
@@ -2,14 +2,14 @@ import NavBar from '@/components/NavBar'
 import { JobTable } from '@/components/JobTable'
 import { KanbanBoard } from '@/components/KanbanBoard'
 import { IconToggle } from '@/components/IconToggle'
-import { Kanban, LayoutList } from 'lucide-react'
+import { Menu, Columns3 } from 'lucide-react'
 import { useState } from 'react'
 
 type ViewMode = 'table' | 'kanban'
 
 const VIEW_OPTIONS = [
-  { value: 'table' as const,  icon: <LayoutList className="h-4 w-4" /> },
-  { value: 'kanban' as const, icon: <Kanban className="h-4 w-4" /> },
+  { value: 'table' as const,  icon: <Menu className="h-4 w-4" /> },
+  { value: 'kanban' as const, icon: <Columns3 className="h-4 w-4" /> },
 ]
 
 function JobPage() {

--- a/job-tracker-ui/src/pages/JobPage.tsx
+++ b/job-tracker-ui/src/pages/JobPage.tsx
@@ -33,8 +33,8 @@ function JobPage() {
         </div>
       </div>
 
-      <div className={`${viewMode === 'kanban' ? 'max-w-7xl px-2' : 'max-w-5xl px-4'} mx-auto pb-1 flex-1 flex flex-col min-h-0`}>
-        <div className={`bg-card rounded-lg shadow-sm ${viewMode === 'kanban' ? 'px-4 pt-4 pb-0' : 'px-4 pt-3 pb-0'} flex-1 flex flex-col min-h-0`}>
+      <div className={`${viewMode === 'kanban' ? 'max-w-7xl px-2' : 'max-w-5xl px-4'} mx-auto w-full pb-1 flex-1 flex flex-col min-h-0 min-w-0`}>
+        <div className={`bg-card rounded-lg shadow-sm ${viewMode === 'kanban' ? 'px-4 pt-4 pb-0' : 'px-4 pt-3 pb-0'} flex-1 flex flex-col min-h-0 min-w-0`}>
           {viewMode === 'table' ? <JobTable /> : <KanbanBoard />}
         </div>
       </div>


### PR DESCRIPTION
This pull request introduces a new reusable `IconToggle` component to improve the view toggle UI in the job tracker app, replacing the previous button group for switching between table and kanban views. It also adds a tooltip utility, polishes layout and accessibility, and updates documentation to reflect these changes.

**UI Component Improvements:**

* Added a new `IconToggle` component (`job-tracker-ui/src/components/IconToggle.tsx`) that provides a pill-shaped, animated, icon-based toggle group for mutually exclusive view/mode switching. This component improves the clarity and polish of the view toggle.
* Updated `JobPage.tsx` to use the new `IconToggle` for switching between table and kanban views, replacing the previous button-based implementation and adjusting icons for clarity.

**Layout and Accessibility Enhancements:**

* Improved layout robustness by adding `min-w-0` to key flex containers in `JobTable.tsx` and `JobPage.tsx`, preventing overflow and ensuring proper flexbox behavior. [[1]](diffhunk://#diff-7bceb6509ca39c7f56f6499dffe0aa8bae67b391bd3004dd0d8beae2a8895689L311-R311) [[2]](diffhunk://#diff-7bceb6509ca39c7f56f6499dffe0aa8bae67b391bd3004dd0d8beae2a8895689L328-R328) [[3]](diffhunk://#diff-d1e4588cfd3962604ca15665f5fcfc8cd34b6d0f434bb0fb7cacc62b0101d1adL4-R26)

**Infrastructure and Utilities:**

* Introduced a new tooltip utility based on Radix UI in `job-tracker-ui/src/components/ui/tooltip.tsx`, providing a consistent way to add tooltips throughout the app.

**Documentation:**

* Updated `docs/progress.md` to reflect the extraction and polish of the view toggle as an in-progress feature, referencing the new `IconToggle.tsx` component.