### PR TITLE
Feat/dashboard analytics

### DIFF
--- a/docs/plans/dashboard-analytics.md
+++ b/docs/plans/dashboard-analytics.md
@@ -22,7 +22,7 @@ Three-way split used across all widgets:
 | **Won** | Offer |
 | **Closed** | Rejected, Withdrawn, No Response |
 
-New enum values to add: `Assessment`, `Withdrawn`. (`NoResponse` already exists.)
+New enum values `Assessment`, `Withdrawn`, `NoResponse` — already shipped.
 
 Response rate formula:
 ```

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,102 +1,5 @@
 C#/.NET job application tracker project. Full-stack ASP.NET Core 10 Web API + React 19, EF Core 10, PostgreSQL, Docker. Dev environment runs in a Dev Container. Live at [jobtracker.nagarenegishi.com](https://jobtracker.nagarenegishi.com).
 
-## Project Structure
-
-```
-Job-Application-Tracker/
-├── .devcontainer/              # Dev Container (Docker + Dockerfile + firewall script)
-├── .github/                    # dependabot.yml + GitHub Actions workflows (deploy, demo-reset)
-├── .vscode/                    # launch.json, tasks.json
-├── .claude/                    # Claude Code settings + skills
-├── JobTrackerApi/              # Backend (ASP.NET Core 10)
-├── JobTrackerApi.Tests/        # xUnit tests
-├── job-tracker-ui/             # Frontend (React 19 + TypeScript + Vite)
-├── uploads/                    # Local document storage (dev only)
-├── docs/                       # Committed project documentation
-├── notes/                      # Local notes (not committed)
-├── compose.yaml                # Dev container compose (app + db services)
-├── compose.prod.yml            # Production Docker Compose (nginx + backend)
-├── Job-Application-Tracker.sln
-└── CLAUDE.md
-```
-
-## Backend — JobTrackerApi/
-
-### Controllers/
-- `AuthController` — unauthenticated auth flows at `/api/auth/`: register, login, refresh, logout, demo login, demo reset, email confirmation, resend confirmation, forgot password, reset password, cleanup unverified accounts
-- `AccountController` — authenticated account management at `/api/account/`: change password
-- `JobsController` — CRUD + JSON Patch at `/api/jobs`. All endpoints `[Authorize]`.
-- `DocumentsController` — Upload/download/delete at `/api/jobs/{jobId}/documents`. All endpoints `[Authorize]`. Demo user blocked from upload/delete (403).
-
-### Models/
-- `Job`, `Document` — EF Core entities with `ToResponseDto()` methods
-- `Contact`, `Correspondence` — Owned types, stored as JSON columns in Jobs table (not separate tables)
-- `RefreshToken` — Tracks issued refresh tokens for rotation/revocation
-- `JobDTO`, `UpdateJobDTO`, `DocumentDTO`, `UpdateDocumentDTO` — Request DTOs with validation
-- `JobResponseDto`, `DocumentResponseDto` — Response shapes (strips internal fields like StoredName)
-- `AuthDTO` — `RegisterDTO`, `LoginDTO`, `ChangePasswordDTO`
-- `DemoSeed` — static class; holds sample job keys + `CreateJobs(userId)` for demo data seeding
-- `ValidationConstants` — Max lengths, file size, allowed extensions
-- Enums: `JobStatus`, `Priority`, `DocumentType` — serialized as strings
-
-### Services/
-- `IStorageService` — Interface: `SaveAsync`, `DeleteAsync`, `GetAsync`, `GetDownloadUrlAsync`
-- `LocalStorageService` — Writes files to `Storage:UploadsPath` on disk (dev)
-- `S3StorageService` — S3 upload/delete/pre-signed URL (prod)
-- `IEmailService` — Interface: `SendAsync(to, subject, htmlBody)`
-- `LogEmailService` — Logs to console (dev)
-- `ResendEmailService` — HTTP POST to Resend API (prod); `SesEmailService` kept but commented out
-
-### Data/
-- `JobTrackerContext` — EF Core DbContext. DbSets: Jobs, Documents, Users (IdentityUser), RefreshTokens.
-- `JobTrackerContextFactory` — `IDesignTimeDbContextFactory<JobTrackerContext>` for EF CLI migrations (bypasses fail-fast JWT validation in Program.cs)
-
-### Migrations (applied)
-1. `InitialCreate`
-2. `AddDocumentStoredName`
-3. `UpdateSchema`
-4. `InitializeCollectionsAsEmpty`
-5. `RenameFilePathToStorageKey`
-
-### Packages
-- `Npgsql.EntityFrameworkCore.PostgreSQL` v10.0.0
-- `Microsoft.EntityFrameworkCore.Design` + `.Tools` v10.0.3
-- `Microsoft.AspNetCore.Authentication.JwtBearer` v10.0.5
-- `Microsoft.AspNetCore.Identity.EntityFrameworkCore` v10.0.5
-- `Microsoft.AspNetCore.JsonPatch.SystemTextJson` v10.0.3
-- `Microsoft.AspNetCore.OpenApi` + `NSwag.AspNetCore` — Swagger in dev
-- `Serilog.AspNetCore`, `Serilog.Sinks.Console` — structured logging
-- `AWSSDK.S3`, `AWSSDK.Extensions.NETCore.Setup` — S3 storage
-- `AWSSDK.SimpleEmailV2` — SES (kept, currently unused; Resend used instead)
-- `Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore` — `/health` endpoint
-- `dotnet-ef` installed globally in dev container
-
-## Frontend — job-tracker-ui/
-
-```
-src/
-├── pages/          JobPage.tsx, JobDetailPage.tsx, LoginPage.tsx, RegisterPage.tsx,
-│                   SettingsPage.tsx, CheckEmailPage.tsx, ConfirmEmailPage.tsx,
-│                   ForgotPasswordPage.tsx, ResetPasswordPage.tsx
-├── components/     JobTable, JobHeader, JobInfoCard, JobFilterBar, JobCreateSheet,
-│                   JobEditSheet, ContactList, CorrespondenceList, DocumentCard,
-│                   DocumentList, NavBar, ProtectedRoute, UnderlinedText
-│   └── ui/         shadcn/ui primitives + DatePicker, StatusBadge, PriorityDot
-├── hooks/          jobQuery.ts, documentQuery.ts, useJobFilters.ts
-├── services/       authService.ts, jobService.ts, documentService.ts
-├── lib/            api.ts (apiFetch wrapper), auth.ts (silentRefresh), utils.ts,
-│                   validationConstants.ts
-└── types/          job.ts, jobDocument.ts, contact.ts, enums.ts
-```
-
-### Key packages
-- React 19, React Router 7, TanStack Query v5
-- Tailwind CSS v4, shadcn/ui (Radix), lucide-react
-- date-fns, react-day-picker
-- TypeScript ~5.9, Vite 7
-
-### Routing
-`/` → `/jobs`, `/jobs/:id`, `/login`, `/register`, `/settings`, `/check-email`, `/confirm-email`, `/forgot-password`, `/reset-password`. All job + account routes wrapped in `ProtectedRoute`.
 
 ## Key Decisions
 
@@ -137,16 +40,6 @@ src/
 - Demo mode 403 on upload/delete shows inline message (not generic error toast)
 - After register: redirect to `/check-email` with email in router state; resend cooldown 2 min
 
-## Tests — JobTrackerApi.Tests/
-
-- `JobDTOTests.cs` — DTO validation
-- `DocumentDTOTests.cs` — Document DTO validation
-- `JobsControllerTests.cs` — Jobs CRUD
-- `DocumentsControllerTests.cs` — Document upload/download/delete
-
-In-memory EF Core DB (unique GUID per test class). Controllers instantiated directly — no HTTP pipeline. `IStorageService` mocked via Moq. `ClaimsPrincipal` set up manually for `[Authorize]`.
-
-Packages: xUnit v2.9.3, Moq v4.20.72, `Microsoft.EntityFrameworkCore.InMemory` v10.0.3
 
 ## Dev Container
 
@@ -221,4 +114,4 @@ All planned steps complete. See `docs/Demo and Auth Features Plan.md` for full d
 | Job application rating API | Crowdsourced company ratings; separate product; scoring weights not finalized | Early planning |
 | Table scroll accessibility | Viewport-contained flex chain; `table-plain.tsx`; sticky `TableHeader`; see `docs/plans/table-scroll-accessibility.md` | Done |
 | Action bar layout fix | Move "Add New Job" + "Show/Hide Columns" into the view toggle row (`JobPage.tsx`) so they anchor to window edge — prevents clipping on narrow viewports; requires lifting add-job dialog trigger out of `JobTable` | Pending |
-| — | View toggle + column selector polish | `IconToggle.tsx` extracted from `JobPage`; pill shape, animated check icon, blue active state; `ColumnToggle` icon + scroll still pending | In Progress |
+| — | View toggle + column selector polish | `IconToggle.tsx`: pill shape, animated check, blue active state. `ColumnToggle`: `Settings2` icon-only, `w-auto` popover, right-edge aligned, always-below, viewport-aware scroll | Done |

--- a/job-tracker-ui/src/components/ColumnToggle.tsx
+++ b/job-tracker-ui/src/components/ColumnToggle.tsx
@@ -52,8 +52,8 @@ export function ColumnToggle() {
           <SlidersHorizontal className="h-4 w-4" />
         </Button>
       </PopoverTrigger>
-      <PopoverContent align="end" side="bottom" avoidCollisions={false} className="w-48 p-2">
-        <div className="flex flex-col gap-1 max-h-[80vh] overflow-y-auto">
+      <PopoverContent align="end" side="bottom" avoidCollisions={false} className="w-48 p-1">
+        <div className="flex flex-col gap-0.5 max-h-[var(--radix-popover-content-available-height)] overflow-y-auto">
           {TOGGLEABLE.map((col) => (
             <label
               key={col.key}

--- a/job-tracker-ui/src/components/ColumnToggle.tsx
+++ b/job-tracker-ui/src/components/ColumnToggle.tsx
@@ -49,8 +49,7 @@ export function ColumnToggle() {
     <Popover open={open} onOpenChange={handleOpenChange}>
       <PopoverTrigger asChild>
         <Button variant="outline" size="sm" className="shadow-xs hover:bg-secondary">
-          <SlidersHorizontal className="mr-2 h-4 w-4" />
-          Show/Hide Columns
+          <SlidersHorizontal className="h-4 w-4" />
         </Button>
       </PopoverTrigger>
       <PopoverContent align="start" className="w-48 p-2">

--- a/job-tracker-ui/src/components/ColumnToggle.tsx
+++ b/job-tracker-ui/src/components/ColumnToggle.tsx
@@ -8,7 +8,7 @@ import {
 import { usePreferences, useUpdatePreferences } from "@/hooks/preferencesQuery";
 import { COLUMNS } from "@/lib/columns";
 import type { ColumnKey } from "@/lib/columns";
-import { SlidersHorizontal } from "lucide-react";
+import { Settings2 } from "lucide-react";
 import { useState } from "react";
 
 // Fixed columns are always visible; only non-fixed columns appear in this toggle list.
@@ -49,10 +49,10 @@ export function ColumnToggle() {
     <Popover open={open} onOpenChange={handleOpenChange}>
       <PopoverTrigger asChild>
         <Button variant="outline" size="sm" className="shadow-xs hover:bg-secondary">
-          <SlidersHorizontal className="h-4 w-4" />
+          <Settings2 className="h-4 w-4" />
         </Button>
       </PopoverTrigger>
-      <PopoverContent align="end" side="bottom" avoidCollisions={false} className="w-48 p-1">
+      <PopoverContent align="end" side="bottom" avoidCollisions={false} className="w-auto p-1">
         <div className="flex flex-col gap-0.5 max-h-[var(--radix-popover-content-available-height)] overflow-y-auto">
           {TOGGLEABLE.map((col) => (
             <label

--- a/job-tracker-ui/src/components/ColumnToggle.tsx
+++ b/job-tracker-ui/src/components/ColumnToggle.tsx
@@ -53,7 +53,7 @@ export function ColumnToggle() {
         </Button>
       </PopoverTrigger>
       <PopoverContent align="start" className="w-48 p-2">
-        <div className="flex flex-col gap-1">
+        <div className="flex flex-col gap-1 max-h-[80vh] overflow-y-auto">
           {TOGGLEABLE.map((col) => (
             <label
               key={col.key}

--- a/job-tracker-ui/src/components/ColumnToggle.tsx
+++ b/job-tracker-ui/src/components/ColumnToggle.tsx
@@ -52,7 +52,7 @@ export function ColumnToggle() {
           <SlidersHorizontal className="h-4 w-4" />
         </Button>
       </PopoverTrigger>
-      <PopoverContent align="start" className="w-48 p-2">
+      <PopoverContent align="end" side="bottom" avoidCollisions={false} className="w-48 p-2">
         <div className="flex flex-col gap-1 max-h-[80vh] overflow-y-auto">
           {TOGGLEABLE.map((col) => (
             <label

--- a/job-tracker-ui/src/components/JobCreateSheet.tsx
+++ b/job-tracker-ui/src/components/JobCreateSheet.tsx
@@ -18,6 +18,7 @@ import {
 import {
   Sheet,
   SheetContent,
+  SheetFooter,
   SheetHeader,
   SheetTitle,
 } from "@/components/ui/sheet"
@@ -128,12 +129,12 @@ export function JobCreateSheet({ open, onOpenChange, initialData }: JobCreateShe
 
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent className="overflow-y-auto sm:max-w-lg">
+      <SheetContent className="sm:max-w-lg">
         <SheetHeader>
           <SheetTitle>Add New Job</SheetTitle>
         </SheetHeader>
 
-        {/* form fields go here */}
+        <div className="flex-1 overflow-y-auto px-4 space-y-4">
 
         {/* Edit Company */}
         <div className="space-y-1.5">
@@ -321,8 +322,10 @@ export function JobCreateSheet({ open, onOpenChange, initialData }: JobCreateShe
           <p className="text-xs text-muted-foreground text-right">{form.notes.length} / {MAX_NOTES_LENGTH}</p>
         </div>
 
+        </div>
+
         {/* Action buttons */}
-        <div className="flex gap-2 pt-2">
+        <SheetFooter className="flex-row">
           {/* Cancel just closes the sheet without saving */}
           <Button
             variant="outline"
@@ -340,7 +343,7 @@ export function JobCreateSheet({ open, onOpenChange, initialData }: JobCreateShe
           >
             {isPending ? "Saving..." : "Save"}
           </Button>
-        </div>
+        </SheetFooter>
       </SheetContent>
     </Sheet>
   )

--- a/job-tracker-ui/src/components/JobCreateSheet.tsx
+++ b/job-tracker-ui/src/components/JobCreateSheet.tsx
@@ -325,11 +325,11 @@ export function JobCreateSheet({ open, onOpenChange, initialData }: JobCreateShe
         </div>
 
         {/* Action buttons */}
-        <SheetFooter className="flex-row">
+        <SheetFooter className="flex-row justify-between">
           {/* Cancel just closes the sheet without saving */}
           <Button
             variant="outline"
-            className="flex-1"
+            className="hover:bg-gray-200 dark:hover:bg-gray-700"
             onClick={() => onOpenChange(false)}
             disabled={isPending}
           >
@@ -337,7 +337,7 @@ export function JobCreateSheet({ open, onOpenChange, initialData }: JobCreateShe
           </Button>
           {/* Save triggers form submission */}
           <Button
-            className="flex-1"
+            className="w-1/2 bg-blue-500 hover:bg-blue-600 text-white"
             onClick={handleSubmit}
             disabled={isPending}
           >

--- a/job-tracker-ui/src/components/JobEditSheet.tsx
+++ b/job-tracker-ui/src/components/JobEditSheet.tsx
@@ -12,6 +12,7 @@ import {
 import {
   Sheet,
   SheetContent,
+  SheetFooter,
   SheetHeader,
   SheetTitle,
 } from "@/components/ui/sheet"
@@ -186,12 +187,12 @@ export function JobEditSheet({ job, open, onOpenChange }: JobEditSheetProps) {
 
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent className="overflow-y-auto sm:max-w-lg">
+      <SheetContent className="sm:max-w-lg">
         <SheetHeader>
           <SheetTitle>Edit Job</SheetTitle>
         </SheetHeader>
 
-        {/* form fields go here */}
+        <div className="flex-1 overflow-y-auto px-4 space-y-4">
 
         {/* Edit Company */}
         <div className="space-y-1.5">
@@ -387,8 +388,10 @@ export function JobEditSheet({ job, open, onOpenChange }: JobEditSheetProps) {
           <p className="text-xs text-muted-foreground text-right">{form.notes.length} / {MAX_NOTES_LENGTH}</p>
         </div>
 
+        </div>
+
         {/* Action buttons */}
-        <div className="flex gap-2 pt-2">
+        <SheetFooter className="flex-row">
           {/* Cancel just closes the sheet without saving */}
           <Button
             variant="outline"
@@ -406,7 +409,7 @@ export function JobEditSheet({ job, open, onOpenChange }: JobEditSheetProps) {
           >
             {isPending ? "Saving..." : "Save"}
           </Button>
-        </div>
+        </SheetFooter>
       </SheetContent>
     </Sheet>
   )

--- a/job-tracker-ui/src/components/JobEditSheet.tsx
+++ b/job-tracker-ui/src/components/JobEditSheet.tsx
@@ -391,11 +391,11 @@ export function JobEditSheet({ job, open, onOpenChange }: JobEditSheetProps) {
         </div>
 
         {/* Action buttons */}
-        <SheetFooter className="flex-row">
+        <SheetFooter className="flex-row justify-between">
           {/* Cancel just closes the sheet without saving */}
           <Button
             variant="outline"
-            className="flex-1"
+            className="hover:bg-gray-200 dark:hover:bg-gray-700"
             onClick={() => onOpenChange(false)}
             disabled={isPending}
           >
@@ -403,7 +403,7 @@ export function JobEditSheet({ job, open, onOpenChange }: JobEditSheetProps) {
           </Button>
           {/* Save triggers form submission */}
           <Button
-            className="flex-1"
+            className="w-1/2 bg-blue-500 hover:bg-blue-600 text-white"
             onClick={handleSubmit}
             disabled={isPending}
           >


### PR DESCRIPTION
This pull request focuses on UI/UX improvements and code cleanup for the job application tracker, particularly in the job create/edit sheets and the column selector. It also updates documentation to reflect recent changes and completed features.

**UI/UX Improvements**

* Updated the `JobCreateSheet` and `JobEditSheet` components to use the `SheetFooter` for action buttons, improving layout and accessibility. The form content is now scrollable and visually separated from the footer. The "Save" button is styled for prominence, and the "Cancel" button uses a more consistent hover state. (`[[1]](diffhunk://#diff-93e9f40486f52c51c61a88cd3357ded1344e37468f6a7ba4e47482bcd93a2242R21)`, `[[2]](diffhunk://#diff-93e9f40486f52c51c61a88cd3357ded1344e37468f6a7ba4e47482bcd93a2242L131-R137)`, `[[3]](diffhunk://#diff-93e9f40486f52c51c61a88cd3357ded1344e37468f6a7ba4e47482bcd93a2242R325-R346)`, `[[4]](diffhunk://#diff-3f7df7509b3895b0c05f27d490e8c977b15012bb7aaf856d5a07fdf849d53a80R15)`, `[[5]](diffhunk://#diff-3f7df7509b3895b0c05f27d490e8c977b15012bb7aaf856d5a07fdf849d53a80L189-R195)`, `[[6]](diffhunk://#diff-3f7df7509b3895b0c05f27d490e8c977b15012bb7aaf856d5a07fdf849d53a80R391-R412)`)
* Improved the `ColumnToggle` component: replaced the icon with `Settings2`, made the popover width auto, aligned to the right edge, and ensured the popover is always below the trigger with viewport-aware scrolling. (`[[1]](diffhunk://#diff-66efc98f21a2eb96be8cddb09ecd59279331f057dc9ea91a2ac920990b3b7e1aL11-R11)`, `[[2]](diffhunk://#diff-66efc98f21a2eb96be8cddb09ecd59279331f057dc9ea91a2ac920990b3b7e1aL52-R56)`)

**Documentation Updates**

* Cleaned up and removed the detailed project structure, backend, frontend, and test documentation sections from `docs/progress.md` to reduce duplication and keep docs concise. (`[[1]](diffhunk://#diff-378b8e52823d637f240b08446ef15475f13745a2cabebff169eb567074cba6b3L3-L99)`, `[[2]](diffhunk://#diff-378b8e52823d637f240b08446ef15475f13745a2cabebff169eb567074cba6b3L140-L149)`)
* Updated the dashboard analytics plan to clarify that new enum values (`Assessment`, `Withdrawn`, `NoResponse`) are already shipped. (`[docs/plans/dashboard-analytics.mdL25-R25](diffhunk://#diff-6c384d7d45f35f42aa346042d73838458fac20bfcd7ca49d19b08bece14b80b0L25-R25)`)
* Marked the "View toggle + column selector polish" as done, reflecting the completed UI improvements. (`[docs/progress.mdL224-R117](diffhunk://#diff-378b8e52823d637f240b08446ef15475f13745a2cabebff169eb567074cba6b3L224-R117)`)