### PR TITLE
Feat/dashboard analytics

### DIFF
--- a/docs/plans/dashboard-analytics.md
+++ b/docs/plans/dashboard-analytics.md
@@ -6,11 +6,11 @@ Route: `/dashboard`. No new backend model or endpoint required — computed from
 
 `appliedAt` must be reliably filled for the weekly chart and response rate to be accurate.
 
-### Auto-fill appliedAt on status change
+### Auto-fill appliedAt on status change — Done
 
 - **Backend** (`JobsController.PatchJob`): when PATCH sets `status = Applied` and current `appliedAt` is null → set `appliedAt = now`. Enforces the rule at the API level regardless of caller.
-- **Frontend**: when user changes status to `Applied` and `appliedAt` is already set → show confirm dialog: *"Applied At is [date]. Reset to today?"* Yes adds `appliedAt` to the patch; No patches status only.
-- Covers Kanban drag and any inline status change.
+- **Frontend** (`JobEditSheet`, `KanbanBoard`): when user changes status to `Applied` and `appliedAt` is already set → confirm dialog: *"Applied At is [date]. Reset to today?"* "Reset to today" adds `/appliedAt: now` to the patch; "Keep existing" patches status only. `ConfirmDialog` (generic) / `DeleteConfirmDialog` (wrapper) introduced in `ui/`.
+- Covers Kanban drag and edit sheet submit.
 
 ## Status classification
 

--- a/docs/plans/desktop-app.md
+++ b/docs/plans/desktop-app.md
@@ -1,0 +1,52 @@
+# Desktop App Version
+
+Separate project (fork of this repo). Single-user, local-only, no cloud services.
+
+## Approach
+
+Clone the repo into a new project. The two versions diverge permanently — different auth model, DB, deployment — so a shared codebase with feature flags would make both worse.
+
+## What gets removed
+
+| Area | Removed |
+|---|---|
+| Auth | JWT, refresh tokens, email confirmation, forgot-password, register, login pages |
+| Admin | User management, AI-access toggle, `AdminController`, `AdminPage` |
+| Demo | Seeded data, demo reset, demo login, `DemoSeed` |
+| Database | PostgreSQL + Npgsql → SQLite |
+| Storage | S3 / cloud path → local filesystem only (`LocalStorageService` kept, path managed by app) |
+| Email service | `IEmailService`, `ResendEmailService`, `LogEmailService`, all email flows |
+| Rate limiting | All per-IP policies (`auth`, `resend-confirmation`, `parse`) |
+| CORS | Removed — loopback only |
+
+## What gets added / changed
+
+- **API key settings screen** — user enters their Claude API key; stored in OS keychain, not a config file
+- **AI feature gating** — AI features enabled if API key is present, disabled with a prompt to add one if not
+- **First-run setup** — on launch with no stored API key, surface the settings screen
+- **Data export** — simple JSON export of all jobs; no cloud backup so this is the only safety net
+- **SQLite file location** — OS app data dir (`%APPDATA%`, `~/Library/Application Support`, `~/.local/share`), not next to the binary
+- **Document storage path** — fixed to a folder inside the same app data dir; user-selectable path is a later option
+- **Auto-update mechanism** — depends on shell choice (TBD)
+
+## Decided
+
+- Platform: desktop first (Windows, Mac, Linux); mobile deferred
+- Separate project (fork), not a monorepo or shared codebase
+- No auth — single user, app launches straight into jobs list
+- SQLite via EF Core (package swap + connection string; migrations still work)
+- API key in OS keychain — not a plain config file or localStorage
+- AI features gated on keychain entry being present
+- LocalStorageService kept; path pointed at app data dir
+- Data export (JSON) included from day one
+- Admin and demo features not carried over
+
+## Not decided
+
+- Desktop shell (Tauri / Electron / other) — affects auto-update, keychain access method, binary size, sidecar vs native backend; Tauri 2.0 worth noting as it supports mobile later without an architecture change
+
+## Open questions (shell-dependent)
+
+- .NET backend as sidecar process, or replace with something native to the shell?
+- Sidecar crash handling and restart strategy
+- Code signing / notarization pipeline (required for Mac, recommended for Windows)

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -101,7 +101,7 @@ All planned steps complete. See `docs/Demo and Auth Features Plan.md` for full d
 | RDS maintenance window | EventBridge stops DB 00:00–08:00 AEST; backend 503 on `DbException`; frontend `MaintenanceError` with time-aware message |
 | Company Verification API | External repo; live at `https://company-verification.onrender.com`; NZ + AU registries; not yet integrated into this project |
 | Dark mode + custom themes | Dark/light toggle in NavBar; 4 color themes (blue, red, yellow, pink); applied via `.theme-*` on `<html>`; stored in `UserPreferences.theme` |
-| Assessment + Withdrawn statuses | New enum values 7/8; auto-fill `appliedAt` on POST (non-Wishlist) and PATCH (→ Applied); Kanban column order and tab filters updated |
+| Assessment + Withdrawn statuses | New enum values 7/8; auto-fill `appliedAt` on POST (non-Wishlist) and PATCH (→ Applied); confirm dialog when status changes to Applied and `appliedAt` already set (`JobEditSheet` + `KanbanBoard`); `ConfirmDialog` generic base + `DeleteConfirmDialog` wrapper in `ui/`; Kanban column order and tab filters updated |
 
 ## Active / Upcoming Work
 

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -102,6 +102,7 @@ All planned steps complete. See `docs/Demo and Auth Features Plan.md` for full d
 | Company Verification API | External repo; live at `https://company-verification.onrender.com`; NZ + AU registries; not yet integrated into this project |
 | Dark mode + custom themes | Dark/light toggle in NavBar; 4 color themes (blue, red, yellow, pink); applied via `.theme-*` on `<html>`; stored in `UserPreferences.theme` |
 | Assessment + Withdrawn statuses | New enum values 7/8; auto-fill `appliedAt` on POST (non-Wishlist) and PATCH (→ Applied); confirm dialog when status changes to Applied and `appliedAt` already set (`JobEditSheet` + `KanbanBoard`); `ConfirmDialog` generic base + `DeleteConfirmDialog` wrapper in `ui/`; Kanban column order and tab filters updated |
+| Kanban drag polish | DragOverlay: `shadow-2xl`, `scale-105`, `rotate-1`; origin card ring + `bg-primary/5` highlight while dragging, persists while appliedAt confirm dialog is open |
 
 ## Active / Upcoming Work
 

--- a/job-tracker-ui/src/components/JobEditSheet.tsx
+++ b/job-tracker-ui/src/components/JobEditSheet.tsx
@@ -435,7 +435,7 @@ export function JobEditSheet({ job, open, onOpenChange }: JobEditSheetProps) {
           open={confirmOpen}
           onOpenChange={setConfirmOpen}
           title="Update Applied Date?"
-          description={<>{`Applied At is currently ${new Date(job.appliedAt!).toLocaleDateString()}.`}<br />Reset to today?</>}
+          description={<>{`You applied on ${new Date(job.appliedAt!).toLocaleDateString()}.`}<br />Reset to today?</>}
           confirmLabel="Reset to today"
           onConfirm={handleResetAppliedAt}
           onCancel={handleKeepAppliedAt}

--- a/job-tracker-ui/src/components/JobEditSheet.tsx
+++ b/job-tracker-ui/src/components/JobEditSheet.tsx
@@ -431,6 +431,15 @@ export function JobEditSheet({ job, open, onOpenChange }: JobEditSheetProps) {
             {isPending ? "Saving..." : "Save"}
           </Button>
         </SheetFooter>
+        <ConfirmDialog
+          open={confirmOpen}
+          onOpenChange={setConfirmOpen}
+          title="Update Applied Date?"
+          description={`Applied At is currently ${new Date(job.appliedAt!).toLocaleDateString()}. Reset to today?`}
+          confirmLabel="Reset to today"
+          onConfirm={handleResetAppliedAt}
+          onCancel={handleKeepAppliedAt}
+        />
       </SheetContent>
     </Sheet>
   )

--- a/job-tracker-ui/src/components/JobEditSheet.tsx
+++ b/job-tracker-ui/src/components/JobEditSheet.tsx
@@ -30,6 +30,7 @@ import {
 import { JobStatus, Priority, WorkMode, formatEnumLabel } from "@/types/enums"
 import type { Job, JobPatchOperation } from "@/types/job"
 import { useEffect, useState } from "react"
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog"
 
 // FormState represents the internal state of the job edit form
 interface FormState {
@@ -90,6 +91,8 @@ export function JobEditSheet({ job, open, onOpenChange }: JobEditSheetProps) {
   const [form, setForm] = useState<FormState>(() => toFormState(job))
   const { mutate: patchJob, isPending } = usePatchJob()
   const [errors, setErrors] = useState<{ jobUrl?: string; salary?: string }>({})
+  const [confirmOpen, setConfirmOpen] = useState(false)
+  const [pendingOps, setPendingOps] = useState<JobPatchOperation[]>([])
 
   // Reset form when sheet opens with fresh job data
   useEffect(() => {
@@ -178,11 +181,29 @@ export function JobEditSheet({ job, open, onOpenChange }: JobEditSheetProps) {
       return
     }
 
+    // Ask before resetting appliedAt when status changes to Applied and date is already set
+    const statusChangingToApplied = form.status === JobStatus.Applied && job.status !== JobStatus.Applied
+    const appliedAtUnchanged = !operations.some(op => op.path === "/appliedAt")
+    if (statusChangingToApplied && job.appliedAt != null && appliedAtUnchanged) {
+      setPendingOps(operations)
+      setConfirmOpen(true)
+      return
+    }
+
     // Trigger the patch
     patchJob(
       { id: job.id, operations },
       { onSuccess: () => onOpenChange(false) }
     )
+  }
+
+  function handleResetAppliedAt() {
+    const ops = [...pendingOps, { op: "replace" as const, path: "/appliedAt", value: new Date().toISOString() }]
+    patchJob({ id: job.id, operations: ops }, { onSuccess: () => onOpenChange(false) })
+  }
+
+  function handleKeepAppliedAt() {
+    patchJob({ id: job.id, operations: pendingOps }, { onSuccess: () => onOpenChange(false) })
   }
 
   return (

--- a/job-tracker-ui/src/components/JobEditSheet.tsx
+++ b/job-tracker-ui/src/components/JobEditSheet.tsx
@@ -198,7 +198,7 @@ export function JobEditSheet({ job, open, onOpenChange }: JobEditSheetProps) {
   }
 
   function handleResetAppliedAt() {
-    const ops = [...pendingOps, { op: "replace" as const, path: "/appliedAt", value: new Date().toISOString() }]
+    const ops: JobPatchOperation[] = [...pendingOps, { op: "replace" as const, path: "/appliedAt" as const, value: new Date().toISOString() }]
     patchJob({ id: job.id, operations: ops }, { onSuccess: () => onOpenChange(false) })
   }
 
@@ -435,7 +435,7 @@ export function JobEditSheet({ job, open, onOpenChange }: JobEditSheetProps) {
           open={confirmOpen}
           onOpenChange={setConfirmOpen}
           title="Update Applied Date?"
-          description={`Applied At is currently ${new Date(job.appliedAt!).toLocaleDateString()}. Reset to today?`}
+          description={<>{`Applied At is currently ${new Date(job.appliedAt!).toLocaleDateString()}.`}<br />Reset to today?</>}
           confirmLabel="Reset to today"
           onConfirm={handleResetAppliedAt}
           onCancel={handleKeepAppliedAt}

--- a/job-tracker-ui/src/components/KanbanBoard.tsx
+++ b/job-tracker-ui/src/components/KanbanBoard.tsx
@@ -213,7 +213,7 @@ export function KanbanBoard() {
         open={confirmJob != null}
         onOpenChange={open => { if (!open) setConfirmJob(null) }}
         title="Update Applied Date?"
-        description={`Applied At is currently ${new Date(confirmJob?.appliedAt!).toLocaleDateString()}. Reset to today?`}
+        description={<>{`Applied At is currently ${new Date(confirmJob?.appliedAt!).toLocaleDateString()}.`}<br />Reset to today?</>}
         confirmLabel="Reset to today"
         onConfirm={handleDragResetAppliedAt}
         onCancel={handleDragKeepAppliedAt}

--- a/job-tracker-ui/src/components/KanbanBoard.tsx
+++ b/job-tracker-ui/src/components/KanbanBoard.tsx
@@ -209,6 +209,15 @@ export function KanbanBoard() {
           </div>
         ) : null}
       </DragOverlay>
+      <ConfirmDialog
+        open={confirmJob != null}
+        onOpenChange={open => { if (!open) setConfirmJob(null) }}
+        title="Update Applied Date?"
+        description={`Applied At is currently ${new Date(confirmJob?.appliedAt!).toLocaleDateString()}. Reset to today?`}
+        confirmLabel="Reset to today"
+        onConfirm={handleDragResetAppliedAt}
+        onCancel={handleDragKeepAppliedAt}
+      />
     </DndContext>
   )
 }

--- a/job-tracker-ui/src/components/KanbanBoard.tsx
+++ b/job-tracker-ui/src/components/KanbanBoard.tsx
@@ -1,6 +1,7 @@
 // [dnd-kit-legacy] migrate to @dnd-kit/react when v1.0 is stable
 
 import { useState } from 'react'
+import { ConfirmDialog } from '@/components/ui/ConfirmDialog'
 import { DndContext, DragOverlay, PointerSensor, useDraggable, useDroppable, useSensor, useSensors } from '@dnd-kit/core'
 import type { DragEndEvent, DragStartEvent, Modifier } from '@dnd-kit/core'
 import { useNavigate } from 'react-router'
@@ -122,6 +123,7 @@ export function KanbanBoard() {
   const sensors = useSensors(useSensor(PointerSensor))
   const [activeJob, setActiveJob] = useState<Job | null>(null)
   const [draggingId, setDraggingId] = useState<number | null>(null)
+  const [confirmJob, setConfirmJob] = useState<Job | null>(null)
 
   function handleDragStart(event: DragStartEvent) {
     // DragOverlay renders a full card clone, so we need the Job object.
@@ -138,10 +140,34 @@ export function KanbanBoard() {
       setDraggingId(null)
       return
     }
+    const draggedJob = jobs?.find(j => j.id === Number(active.id))
+    // Ask before resetting appliedAt when dragged to Applied and date is already set
+    if (over.id === JobStatus.Applied && draggedJob?.appliedAt != null) {
+      setDraggingId(null)
+      setConfirmJob(draggedJob)
+      return
+    }
     patchJob(
       { id: Number(active.id), operations: [{ op: 'replace', path: '/status', value: over.id as JobStatus }] },
       { onSettled: () => setDraggingId(null) }
     )
+  }
+
+  function handleDragResetAppliedAt() {
+    if (!confirmJob) return
+    patchJob({ id: confirmJob.id, operations: [
+      { op: 'replace', path: '/status', value: JobStatus.Applied },
+      { op: 'replace', path: '/appliedAt', value: new Date().toISOString() },
+    ]})
+    setConfirmJob(null)
+  }
+
+  function handleDragKeepAppliedAt() {
+    if (!confirmJob) return
+    patchJob({ id: confirmJob.id, operations: [
+      { op: 'replace', path: '/status', value: JobStatus.Applied },
+    ]})
+    setConfirmJob(null)
   }
 
   if (isPending) return <p>Loading...</p>

--- a/job-tracker-ui/src/components/KanbanBoard.tsx
+++ b/job-tracker-ui/src/components/KanbanBoard.tsx
@@ -213,7 +213,7 @@ export function KanbanBoard() {
         open={confirmJob != null}
         onOpenChange={open => { if (!open) setConfirmJob(null) }}
         title="Update Applied Date?"
-        description={<>{`You applied on ${new Date(confirmJob?.appliedAt!).toLocaleDateString()}.`}<br />Reset to today?</>}
+        description={<><span className="block [overflow-wrap:anywhere]">{confirmJob?.company}</span>{`You applied on ${new Date(confirmJob?.appliedAt ?? new Date()).toLocaleDateString()}.`}<br />Reset to today?</>}
         confirmLabel="Reset to today"
         onConfirm={handleDragResetAppliedAt}
         onCancel={handleDragKeepAppliedAt}

--- a/job-tracker-ui/src/components/KanbanBoard.tsx
+++ b/job-tracker-ui/src/components/KanbanBoard.tsx
@@ -213,7 +213,7 @@ export function KanbanBoard() {
         open={confirmJob != null}
         onOpenChange={open => { if (!open) setConfirmJob(null) }}
         title="Update Applied Date?"
-        description={<>{`Applied At is currently ${new Date(confirmJob?.appliedAt!).toLocaleDateString()}.`}<br />Reset to today?</>}
+        description={<>{`You applied on ${new Date(confirmJob?.appliedAt!).toLocaleDateString()}.`}<br />Reset to today?</>}
         confirmLabel="Reset to today"
         onConfirm={handleDragResetAppliedAt}
         onCancel={handleDragKeepAppliedAt}

--- a/job-tracker-ui/src/components/KanbanBoard.tsx
+++ b/job-tracker-ui/src/components/KanbanBoard.tsx
@@ -71,7 +71,7 @@ function KanbanCardPreview({ job }: { job: Job }) {
   )
 }
 
-function KanbanCard({ job, isBeingDragged }: { job: Job; isBeingDragged: boolean }) {
+function KanbanCard({ job, isBeingDragged, isPendingConfirm }: { job: Job; isBeingDragged: boolean; isPendingConfirm: boolean }) {
   const navigate = useNavigate()
   const { setNodeRef, listeners, attributes, isDragging } = useDraggable({
     id: job.id,
@@ -90,6 +90,7 @@ function KanbanCard({ job, isBeingDragged }: { job: Job; isBeingDragged: boolean
         "transition-shadow transition-colors",
         isDragging && "opacity-50",
         !isDragging && isBeingDragged && "opacity-0",
+        (isDragging || isPendingConfirm) && "ring-2 ring-primary/60 bg-primary/5",
       )}
     >
       <KanbanCardPreview job={job} />
@@ -97,7 +98,7 @@ function KanbanCard({ job, isBeingDragged }: { job: Job; isBeingDragged: boolean
   )
 }
 
-function KanbanColumn({ status, jobs, draggingId }: { status: JobStatus; jobs: Job[]; draggingId: number | null }) {
+function KanbanColumn({ status, jobs, draggingId, confirmJobId }: { status: JobStatus; jobs: Job[]; draggingId: number | null; confirmJobId: number | null }) {
   const { setNodeRef, isOver } = useDroppable({ id: status })
 
   return (
@@ -110,7 +111,7 @@ function KanbanColumn({ status, jobs, draggingId }: { status: JobStatus; jobs: J
         className={`${COLUMN_BG[status]} rounded-md p-2 flex flex-col gap-2 min-h-[120px] flex-1 ${isOver ? 'ring-2 ring-inset ring-primary/40' : ''}`}
       >
         {jobs.map((job) => (
-          <KanbanCard key={job.id} job={job} isBeingDragged={job.id === draggingId} />
+          <KanbanCard key={job.id} job={job} isBeingDragged={job.id === draggingId} isPendingConfirm={job.id === confirmJobId} />
         ))}
       </div>
     </div>
@@ -183,6 +184,7 @@ export function KanbanBoard() {
               status={status}
               jobs={jobs.filter((j) => j.status === status)}
               draggingId={draggingId}
+              confirmJobId={confirmJob?.id ?? null}
             />
           ))}
           {/* Withdrawn and NoResponse are outside the normal application flow */}
@@ -191,11 +193,13 @@ export function KanbanBoard() {
             status={JobStatus.Withdrawn}
             jobs={jobs.filter((j) => j.status === JobStatus.Withdrawn)}
             draggingId={draggingId}
+            confirmJobId={confirmJob?.id ?? null}
           />
           <KanbanColumn
             status={JobStatus.NoResponse}
             jobs={jobs.filter((j) => j.status === JobStatus.NoResponse)}
             draggingId={draggingId}
+            confirmJobId={confirmJob?.id ?? null}
           />
         </div>
       </div>
@@ -203,7 +207,8 @@ export function KanbanBoard() {
         {activeJob ? (
           <div className={cn(
             "bg-card border border-border rounded-md p-3",
-            "cursor-grabbing shadow-lg",
+            "cursor-grabbing shadow-2xl",
+            "scale-105 rotate-1",
           )}>
             <KanbanCardPreview job={activeJob} />
           </div>

--- a/job-tracker-ui/src/components/ui/ConfirmDialog.tsx
+++ b/job-tracker-ui/src/components/ui/ConfirmDialog.tsx
@@ -1,3 +1,5 @@
+// Generic confirmation dialog used as the base for all confirm/alert flows.
+
 import type { ReactNode } from "react"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
@@ -10,6 +12,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog"
 
+// ConfirmDialogProps defines the props for the ConfirmDialog component
 interface ConfirmDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
@@ -17,9 +20,13 @@ interface ConfirmDialogProps {
   description: ReactNode
   onConfirm: () => void
   confirmLabel: string
-  confirmClassName?: string
+  confirmClassName?: string  // optional styling for the confirm button; omit for plain outline
 }
 
+/**
+ * ConfirmDialog provides a reusable two-button confirmation dialog.
+ * Use confirmLabel and confirmClassName to specialise for a specific action.
+ */
 export function ConfirmDialog({
   open,
   onOpenChange,

--- a/job-tracker-ui/src/components/ui/ConfirmDialog.tsx
+++ b/job-tracker-ui/src/components/ui/ConfirmDialog.tsx
@@ -1,0 +1,54 @@
+import type { ReactNode } from "react"
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+
+interface ConfirmDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  title: string
+  description: ReactNode
+  onConfirm: () => void
+  confirmLabel: string
+  confirmClassName?: string
+}
+
+export function ConfirmDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  onConfirm,
+  confirmLabel,
+  confirmClassName,
+}: ConfirmDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-xs" showCloseButton={false}>
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            variant="outline"
+            className={confirmClassName}
+            onClick={() => { onOpenChange(false); onConfirm() }}
+          >
+            {confirmLabel}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/job-tracker-ui/src/components/ui/ConfirmDialog.tsx
+++ b/job-tracker-ui/src/components/ui/ConfirmDialog.tsx
@@ -1,7 +1,6 @@
 // Generic confirmation dialog used as the base for all confirm/alert flows.
 
 import type { ReactNode } from "react"
-import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import {
   Dialog,

--- a/job-tracker-ui/src/components/ui/ConfirmDialog.tsx
+++ b/job-tracker-ui/src/components/ui/ConfirmDialog.tsx
@@ -21,6 +21,7 @@ interface ConfirmDialogProps {
   onConfirm: () => void
   confirmLabel: string
   confirmClassName?: string  // optional styling for the confirm button; omit for plain outline
+  onCancel?: () => void      // called when Cancel is clicked; omit to just close the dialog
 }
 
 /**
@@ -35,6 +36,7 @@ export function ConfirmDialog({
   onConfirm,
   confirmLabel,
   confirmClassName,
+  onCancel,
 }: ConfirmDialogProps) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -44,7 +46,7 @@ export function ConfirmDialog({
           <DialogDescription>{description}</DialogDescription>
         </DialogHeader>
         <DialogFooter>
-          <Button variant="outline" onClick={() => onOpenChange(false)}>
+          <Button variant="outline" onClick={() => { onOpenChange(false); onCancel?.() }}>
             Cancel
           </Button>
           <Button

--- a/job-tracker-ui/src/components/ui/DeleteConfirmDialog.tsx
+++ b/job-tracker-ui/src/components/ui/DeleteConfirmDialog.tsx
@@ -1,14 +1,8 @@
+// Concrete confirmation dialog for destructive delete actions.
+
 import type { ReactNode } from "react"
 import { cn } from "@/lib/utils"
-import { Button } from "@/components/ui/button"
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog"
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog"
 
 // DeleteConfirmDialogProps defines the props for the DeleteConfirmDialog component
 interface DeleteConfirmDialogProps {
@@ -22,38 +16,15 @@ interface DeleteConfirmDialogProps {
 /**
  * DeleteConfirmDialog provides a reusable confirmation dialog for destructive actions.
  */
-export function DeleteConfirmDialog({
-  open,
-  onOpenChange,
-  title,
-  description,
-  onConfirm,
-}: DeleteConfirmDialogProps) {
+export function DeleteConfirmDialog(props: DeleteConfirmDialogProps) {
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-xs" showCloseButton={false}>
-        {/* Title and description */}
-        <DialogHeader>
-          <DialogTitle>{title}</DialogTitle>
-          <DialogDescription>{description}</DialogDescription>
-        </DialogHeader>
-        {/* Cancel and confirm actions */}
-        <DialogFooter>
-          <Button variant="outline" onClick={() => onOpenChange(false)}>
-            Cancel
-          </Button>
-          <Button
-            variant="outline"
-            className={cn(
-              "border-destructive/50 text-destructive/70",
-              "hover:bg-destructive/10 hover:text-destructive hover:border-destructive"
-            )}
-            onClick={() => { onOpenChange(false); onConfirm() }}
-          >
-            Delete
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+    <ConfirmDialog
+      {...props}
+      confirmLabel="Delete"
+      confirmClassName={cn(
+        "border-destructive/50 text-destructive/70",
+        "hover:bg-destructive/10 hover:text-destructive hover:border-destructive"
+      )}
+    />
   )
 }


### PR DESCRIPTION
This pull request introduces a generic confirmation dialog component and integrates it into both the job edit sheet and Kanban board to confirm resetting the "appliedAt" date when changing a job's status to "Applied" and a date is already set. It also polishes the Kanban drag-and-drop UI and updates documentation to reflect these changes. The most important changes are:

**UI Components: Confirmation Dialogs**
* Added a reusable `ConfirmDialog` component in `ui/ConfirmDialog.tsx` for all confirmation flows, and refactored `DeleteConfirmDialog` to use it as a wrapper for destructive actions. [[1]](diffhunk://#diff-2a93084d0212165fed9fd6256d83caac45b1967e8fc060f15df8d5edddb30331R1-R62) [[2]](diffhunk://#diff-e3e390e7483cd700fcf706ea759d687eb810865741210d5b574062811f556772R1-R5) [[3]](diffhunk://#diff-e3e390e7483cd700fcf706ea759d687eb810865741210d5b574062811f556772L25-R28)
* Integrated `ConfirmDialog` into `JobEditSheet` and `KanbanBoard` to prompt users before resetting `appliedAt` when changing status to "Applied" if a date already exists, covering both inline edits and Kanban drag actions. [[1]](diffhunk://#diff-3f7df7509b3895b0c05f27d490e8c977b15012bb7aaf856d5a07fdf849d53a80R33) [[2]](diffhunk://#diff-3f7df7509b3895b0c05f27d490e8c977b15012bb7aaf856d5a07fdf849d53a80R94-R95) [[3]](diffhunk://#diff-3f7df7509b3895b0c05f27d490e8c977b15012bb7aaf856d5a07fdf849d53a80R184-R208) [[4]](diffhunk://#diff-3f7df7509b3895b0c05f27d490e8c977b15012bb7aaf856d5a07fdf849d53a80R434-R442) [[5]](diffhunk://#diff-b23b2f039bc2f44c07a74105a37a628cc94e677fc1b129cf2c92e63ebfaab489R4) [[6]](diffhunk://#diff-b23b2f039bc2f44c07a74105a37a628cc94e677fc1b129cf2c92e63ebfaab489L73-R74) [[7]](diffhunk://#diff-b23b2f039bc2f44c07a74105a37a628cc94e677fc1b129cf2c92e63ebfaab489R93-R101) [[8]](diffhunk://#diff-b23b2f039bc2f44c07a74105a37a628cc94e677fc1b129cf2c92e63ebfaab489L112-R114) [[9]](diffhunk://#diff-b23b2f039bc2f44c07a74105a37a628cc94e677fc1b129cf2c92e63ebfaab489R127) [[10]](diffhunk://#diff-b23b2f039bc2f44c07a74105a37a628cc94e677fc1b129cf2c92e63ebfaab489R144-R173) [[11]](diffhunk://#diff-b23b2f039bc2f44c07a74105a37a628cc94e677fc1b129cf2c92e63ebfaab489R187) [[12]](diffhunk://#diff-b23b2f039bc2f44c07a74105a37a628cc94e677fc1b129cf2c92e63ebfaab489R196-R225)

**Kanban Board and UI Polish**
* Improved Kanban drag-and-drop visuals: added `shadow-2xl`, `scale-105`, and `rotate-1` to the drag overlay, with persistent ring and highlight while the confirmation dialog is open.

**Documentation Updates**
* Updated documentation and progress tracking to describe the new confirmation dialog flow for resetting `appliedAt` in both the edit sheet and Kanban board, and noted the introduction of `ConfirmDialog` and `DeleteConfirmDialog`. [[1]](diffhunk://#diff-6c384d7d45f35f42aa346042d73838458fac20bfcd7ca49d19b08bece14b80b0L9-R13) [[2]](diffhunk://#diff-378b8e52823d637f240b08446ef15475f13745a2cabebff169eb567074cba6b3L104-R105)
* Added a new plan document for a desktop app version, outlining features to be removed or changed, and decisions yet to be made.