### PR TITLE
Feat/profile analysis

### DIFF
--- a/.github/workflows/demo-reset.yml
+++ b/.github/workflows/demo-reset.yml
@@ -2,9 +2,10 @@ name: Reset Demo Data
 
 on:
   schedule:
-    # RDS shutdown at midnight, GitHub Actions could delay ~2 hr 
-    # Runs ~9:30 PM Sydney time daily
-    - cron: '30 9 * * *'
+    # RDS is down 20:00–07:00 NZ (Pacific/Auckland); this must run while RDS is UP.
+    # cron is UTC: 0 20 UTC = 08:00 NZST / 09:00 NZDT. GitHub's ~2h delay pushes it to
+    # ~10–11am NZ — still ~9h before the 8pm shutdown, and after the 7am startup.
+    - cron: '0 20 * * *'
   workflow_dispatch:       # manual trigger from GitHub Actions UI
 
 jobs:

--- a/.github/workflows/renew-cert.yml
+++ b/.github/workflows/renew-cert.yml
@@ -2,9 +2,9 @@ name: Renew SSL Certificate
 
 on:
   schedule:
-    # 1st of every month at 15:00 UTC = 01:00 AEST.
-    # RDS maintenance window is 00:00–08:00 AEST — site is already in maintenance mode during this window,
-    # so container downtime (if renewal is needed) has no user impact.
+    # 1st of every month at 15:00 UTC = 03:00 NZST / 04:00 NZDT.
+    # RDS is down 20:00–07:00 NZ (site in maintenance mode) — 15:00 UTC lands inside that
+    # window in both seasons, so container downtime (if renewal is needed) has no user impact.
     - cron: '0 15 1 * *'
   workflow_dispatch:
 

--- a/docs/plans/rds-maintenance-window.md
+++ b/docs/plans/rds-maintenance-window.md
@@ -67,3 +67,29 @@ Show users a meaningful maintenance message instead of a generic error during th
 - RDS uptime: 08:00–00:00 AEST = 22:00–14:00 UTC
 - GitHub Actions adds ~2 hr delay to scheduled runs — cron must target no later than 12:00 UTC or the delay risks hitting the 14:00 UTC shutdown
 - Demo reset cron set to `30 9 * * *` UTC → fires ~9:30 PM Sydney time — avoids peak Sydney hours and stays safely within RDS uptime
+
+---
+
+## Phase 2 — NZ timezone + longer shutdown (supersedes the Phase 1 window above)
+
+RDS now runs **07:00–20:00 NZ** (down 20:00–07:00, 11h/day), scheduled in EventBridge with timezone `Pacific/Auckland` (DST-aware). Portfolio-first: up during recruiter hours (unlikely after 8pm); 07:00 start (not 08:00) leaves a buffer since RDS takes ~5–10 min to become available after the start command.
+
+### Scheduled jobs and their coupling to the RDS window
+
+| Job | Location | Cron | Coupling |
+|---|---|---|---|
+| RDS stop | EventBridge Scheduler | `0 20 * * ? *` Pacific/Auckland (20:00 NZ) | anchor |
+| RDS start | EventBridge Scheduler | `0 7 * * ? *` Pacific/Auckland (07:00 NZ) | anchor |
+| demo-reset | `.github/workflows/demo-reset.yml` | `0 20 * * *` UTC | must run while RDS **UP** |
+| renew-cert | `.github/workflows/renew-cert.yml` | `0 15 1 * *` UTC | must run while RDS **DOWN** (maintenance) |
+
+### DST gotcha (why these exact times — don't naively "align" them)
+
+GitHub Actions crons are fixed UTC; EventBridge `Pacific/Auckland` follows NZ DST, so the RDS window shifts ±1h in UTC between NZST (UTC+12) and NZDT (UTC+13). Both couplings hold in both seasons:
+- RDS up (UTC): NZST 19:00–08:00 · NZDT 18:00–07:00
+- demo-reset `0 20` UTC (+≤2h GitHub delay): fires ~08:00–11:00 NZ — inside UP both seasons ✓. (DB is only up in the daytime now, so demo data resets during recruiter hours — accepted.)
+- renew-cert `0 15` UTC: 03:00 NZST / 04:00 NZDT — inside the DOWN window both seasons ✓.
+
+If the window ever changes, re-verify both couplings in both seasons.
+
+**Pending:** the `demo-reset.yml` + `renew-cert.yml` edits are not yet merged to `main`. Scheduled workflows run only from the default branch, so demo-reset fails nightly until merged. The EventBridge schedules are already live.


### PR DESCRIPTION
This pull request updates the RDS maintenance window documentation and adjusts the scheduling of related GitHub Actions workflows to align with a new, longer RDS downtime window in the New Zealand timezone. The changes ensure that automated jobs run only when the RDS instance is in the appropriate state (up or down), and clarify the impact of daylight saving time (DST) on scheduling.

**Documentation updates:**

* Added a new "Phase 2" section to `docs/plans/rds-maintenance-window.md` describing the updated RDS window (07:00–20:00 NZ), the rationale for the change, and a detailed table showing how scheduled jobs (`demo-reset`, `renew-cert`) are coupled to the RDS state, including DST considerations.

**Workflow schedule adjustments:**

* Updated `.github/workflows/demo-reset.yml` to change the scheduled run time to `0 20 * * *` UTC, ensuring the demo reset job only runs while RDS is up in the new NZ window.
* Updated `.github/workflows/renew-cert.yml` with clarified comments to reflect the new RDS window and confirm that the SSL renewal job runs during RDS downtime for zero user impact.