### PR TITLE
Feat/profile analysis

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,7 +104,7 @@ All controllers except `AuthController` require `[Authorize]`. New controllers m
 
 **Data flow**: `pages/` → `hooks/` (TanStack Query) → `services/` (fetch wrappers) → API
 
-- `src/services/` — fetch wrappers using `apiFetch` from `src/lib/api.ts` (never plain `fetch`); `apiFetch` attaches the Bearer token, sends credentials, handles 401 silent refresh, and throws `MaintenanceError` on 503 during scheduled window (midnight–8 AM Sydney); includes `authService.ts`, `adminService.ts`, `preferencesService.ts`; silent refresh logic in `src/lib/auth.ts`
+- `src/services/` — fetch wrappers using `apiFetch` from `src/lib/api.ts` (never plain `fetch`); `apiFetch` attaches the Bearer token, sends credentials, handles 401 silent refresh, and throws `MaintenanceError` on 503 during scheduled window (8 PM–7 AM NZ); includes `authService.ts`, `adminService.ts`, `preferencesService.ts`; silent refresh logic in `src/lib/auth.ts`
 - `src/hooks/` — TanStack Query hooks
 - `src/pages/` — `JobPage` (list), `JobDetailPage` (detail), `LoginPage`, `RegisterPage`, `SettingsPage`, `CheckEmailPage`, `ConfirmEmailPage`, `ForgotPasswordPage`, `ResetPasswordPage`, `AdminPage`, `DashboardPage` (analytics — client-side only, no API endpoint; `dashboardUtils.ts`)
 - `src/components/` — feature components including `KanbanBoard`, `ParseListingDialog`, `ColumnToggle`; `src/components/dashboard/` — dashboard widgets; `src/components/ui/` — shadcn/ui primitives

--- a/docs/plans/maintenance-page.md
+++ b/docs/plans/maintenance-page.md
@@ -1,0 +1,28 @@
+# Maintenance Page — Plan
+
+## Goal
+When the DB is down during the scheduled window, redirect users to a dedicated
+`/maintenance` page instead of showing a bare "Something went wrong" per component.
+
+## Decisions
+- **Redirect, not overlay** — intercept in `apiFetch`; on in-window 503 do
+  `window.location.href = "/maintenance"` (mirrors the existing 401 → `/login` path).
+  One global interception point; makes the per-component `instanceof MaintenanceError`
+  checks redundant.
+- **Keep the clock-window check** — only in-window 503 redirects; outside stays a
+  generic `ApiError`. Trade-off: the ~5–10 min RDS start-up gap after 07:00 NZ shows a
+  generic error, not maintenance — accepted.
+- **`/maintenance` is a public route** — outside `ProtectedRoute`; renders regardless of auth.
+- **Auto-recovery** — page polls the backend health endpoint with plain `fetch`
+  (never `apiFetch`, to avoid a redirect loop); on 200 → navigate back to `/`.
+- **Return destination** — `/` for now (redirect loses the prior URL).
+- **Poll interval** — 30–60 s, plus a manual "Try again" button (RDS start is minutes).
+
+## Steps
+1. `MaintenancePage` component + public `/maintenance` route; health poll + manual retry.
+2. `apiFetch` maintenance branch → `window.location.href = "/maintenance"` before throw.
+3. (Optional) remove now-dead per-component `instanceof MaintenanceError` checks.
+
+## To verify during build
+- Health endpoint path (`/health` at root vs under `VITE_API_BASE_URL`), anonymous access, CORS.
+- Health returns 503 while DB down, 200 when up (`AddDbContextCheck`).

--- a/docs/plans/maintenance-page.md
+++ b/docs/plans/maintenance-page.md
@@ -19,10 +19,12 @@ When the DB is down during the scheduled window, redirect users to a dedicated
 - **Poll interval** — 30–60 s, plus a manual "Try again" button (RDS start is minutes).
 
 ## Steps
-1. `MaintenancePage` component + public `/maintenance` route; health poll + manual retry.
-2. `apiFetch` maintenance branch → `window.location.href = "/maintenance"` before throw.
-3. (Optional) remove now-dead per-component `instanceof MaintenanceError` checks.
+1. `MaintenancePage` component + public `/maintenance` route; health poll + manual retry. Done.
+2. `apiFetch` maintenance branch → `window.location.href = "/maintenance"` before throw. Done.
+3. Remove now-dead per-component `instanceof MaintenanceError` checks (5 files). Done.
 
-## To verify during build
-- Health endpoint path (`/health` at root vs under `VITE_API_BASE_URL`), anonymous access, CORS.
-- Health returns 503 while DB down, 200 when up (`AddDbContextCheck`).
+## Health endpoint
+- `/health` stays at backend root; `nginx.conf` adds a `location /health` proxy block so prod requests reach the backend instead of falling through to the SPA fallback.
+- `HEALTH_URL` in `MaintenancePage.tsx` strips `/api` from `VITE_API_BASE_URL` and appends `/health` — works in dev (hits ASP.NET directly) and prod (hits Nginx → proxied to backend).
+- CORS not needed in prod — same domain through Nginx. Dev uses existing `DevCors` policy.
+- Verified working in dev. Health returns 503 while DB down, 200 when up (`AddDbContextCheck`).

--- a/docs/plans/rds-maintenance-window.md
+++ b/docs/plans/rds-maintenance-window.md
@@ -1,78 +1,26 @@
 # RDS Maintenance Window — Implementation Plan
 
 ## Goal
-Stop RDS daily 00:00–08:00 Sydney time to save ~$10/month.
-Show users a meaningful maintenance message instead of a generic error during that window.
+Stop RDS overnight to save ~$10/month, and show users a maintenance message
+instead of a generic error while the DB is down.
 
 ## Cost context
 - EC2 schedule not worth it — EIP charge eats most of the saving (~$2 net)
 - RDS stop has no penalty — full hourly billing pauses
-- RDS auto-restarts after 7 days (AWS hard limit) — on that day it runs a few unscheduled hours until midnight re-stops it; negligible cost impact
+- RDS auto-restarts after 7 days (AWS hard limit) — on that day it runs a few
+  unscheduled hours until the next scheduled stop; negligible cost impact
 
 ---
 
-## Decisions
+## Current schedule
 
-### Backend
-- Exception handler in `Program.cs` (lines 261–280) currently catches all unhandled exceptions → **500**
-- Change: catch `System.Data.Common.DbException` specifically → return **503** instead of 500
-- All other exceptions remain 500
-- No schedule/clock logic in backend — backend only signals "DB is unreachable"
-- `DbException` is the right base class (covers Npgsql without importing Npgsql directly)
-- Note: `OnTokenValidated` (line 167) also hits DB for SecurityStamp check — will also throw `DbException` → same 503 path covers it
+RDS runs **07:00–20:00 NZ** (down 20:00–07:00, 11h/day), scheduled in
+EventBridge Scheduler with timezone `Pacific/Auckland` (DST-aware). Portfolio-first:
+up during recruiter hours (unlikely after 8pm); 07:00 start (not 08:00) leaves a
+buffer since RDS takes ~5–10 min to become available after the start command.
 
-### Frontend
-- `apiFetch` in `src/lib/api.ts` — add 503 check before the existing 401 check
-- On 503: check browser clock against maintenance window (00:00–08:00 AEST)
-  - In window → throw `MaintenanceError` with message: `"Service is in maintenance (midnight–8 AM Sydney time). Please try again later."`
-  - Outside window → throw `ApiError` with status 503 and message: `"Service temporarily unavailable. Please try again."`
-- Maintenance window constant: `{ startHour: 0, endHour: 8, timezone: "Australia/Sydney" }`
-- Use `Intl.DateTimeFormat` to get current hour in AEST — handles DST automatically
-
-### UI error display
-- **No global toast/error provider exists** — errors are handled per-component
-- `JobTable.tsx:191` — `if (isError) return <p>Something went wrong.</p>` — TanStack Query `isError` catches all query errors
-- `DocumentList.tsx` — uses `isError` and `uploadError` state separately
-- Decision: add a `MaintenanceError` class to `src/lib/api.ts`, check for it in error display locations and show the maintenance message
-- Components to update: `JobTable`, `JobDetailPage`, `DocumentList`, `LoginPage` (login fails with 503 during window)
-- **Per-component for now** — `instanceof MaintenanceError` inline in each component
-- **Future: migrate to `QueryCache` global `onError`** — one handler for all query errors; `MutationCache` needs separate handling; requires adding a context provider or module-level signal for global UI state
-
----
-
-## Files to change
-
-| File | Change |
-|---|---|
-| `JobTrackerApi/Program.cs` | Exception handler: catch `DbException` → 503 |
-| `job-tracker-ui/src/lib/api.ts` | Add `MaintenanceError` class + 503 detection in `apiFetch` |
-| `job-tracker-ui/src/components/JobTable.tsx` | Check `MaintenanceError` in `isError` branch |
-| `job-tracker-ui/src/pages/JobDetailPage.tsx` | Same |
-| `job-tracker-ui/src/components/DocumentList.tsx` | Same |
-| `job-tracker-ui/src/pages/LoginPage.tsx` | Check `instanceof MaintenanceError` first in the catch block, then `instanceof ApiError`; sets `error` state which renders in the existing inline error div (`apiFetch` converts 503 to `MaintenanceError`/`ApiError` before it reaches the page — no raw status check needed) |
-
-## Health check
-- `/health` already returns 503 when DB is down (`AddDbContextCheck`) — no change needed
-
-## AWS schedule setup
-- Use EventBridge Scheduler (not Lambda) — simpler, no code needed
-- Two rules: stop RDS at 00:00 AEST, start RDS at 08:00 AEST
-- Target: `rds:StopDBInstance` / `rds:StartDBInstance`
-- IAM role: must be created manually before setting up the scheduler — grant `rds:StopDBInstance` and `rds:StartDBInstance` on the target DB instance; EventBridge Scheduler assumes this role when invoking the targets
-- Set timezone to `Australia/Sydney` in the scheduler — DST handled automatically, no UTC offset needed
-- Cost: free tier covers 14M invocations/month; this uses ~60/month — $0
-- Not in this repo — done in AWS console or Terraform separately
-
-### Demo reset cron alignment
-- RDS uptime: 08:00–00:00 AEST = 22:00–14:00 UTC
-- GitHub Actions adds ~2 hr delay to scheduled runs — cron must target no later than 12:00 UTC or the delay risks hitting the 14:00 UTC shutdown
-- Demo reset cron set to `30 9 * * *` UTC → fires ~9:30 PM Sydney time — avoids peak Sydney hours and stays safely within RDS uptime
-
----
-
-## Phase 2 — NZ timezone + longer shutdown (supersedes the Phase 1 window above)
-
-RDS now runs **07:00–20:00 NZ** (down 20:00–07:00, 11h/day), scheduled in EventBridge with timezone `Pacific/Auckland` (DST-aware). Portfolio-first: up during recruiter hours (unlikely after 8pm); 07:00 start (not 08:00) leaves a buffer since RDS takes ~5–10 min to become available after the start command.
+Set up in the AWS console / Terraform, not in this repo. EventBridge free tier
+covers 14M invocations/month; this uses ~60/month — $0.
 
 ### Scheduled jobs and their coupling to the RDS window
 
@@ -85,11 +33,44 @@ RDS now runs **07:00–20:00 NZ** (down 20:00–07:00, 11h/day), scheduled in Ev
 
 ### DST gotcha (why these exact times — don't naively "align" them)
 
-GitHub Actions crons are fixed UTC; EventBridge `Pacific/Auckland` follows NZ DST, so the RDS window shifts ±1h in UTC between NZST (UTC+12) and NZDT (UTC+13). Both couplings hold in both seasons:
+GitHub Actions crons are fixed UTC; EventBridge `Pacific/Auckland` follows NZ DST,
+so the RDS window shifts ±1h in UTC between NZST (UTC+12) and NZDT (UTC+13). Both
+couplings hold in both seasons:
 - RDS up (UTC): NZST 19:00–08:00 · NZDT 18:00–07:00
-- demo-reset `0 20` UTC (+≤2h GitHub delay): fires ~08:00–11:00 NZ — inside UP both seasons ✓. (DB is only up in the daytime now, so demo data resets during recruiter hours — accepted.)
+- demo-reset `0 20` UTC (+≤2h GitHub delay): fires ~08:00–11:00 NZ — inside UP both
+  seasons ✓. (DB is only up in the daytime now, so demo data resets during recruiter
+  hours — accepted.)
 - renew-cert `0 15` UTC: 03:00 NZST / 04:00 NZDT — inside the DOWN window both seasons ✓.
 
 If the window ever changes, re-verify both couplings in both seasons.
 
-**Pending:** the `demo-reset.yml` + `renew-cert.yml` edits are not yet merged to `main`. Scheduled workflows run only from the default branch, so demo-reset fails nightly until merged. The EventBridge schedules are already live.
+---
+
+## 503 maintenance handling
+
+### Backend
+- Exception handler in `Program.cs` catches `System.Data.Common.DbException`
+  specifically → returns **503**; all other exceptions stay **500**.
+- No schedule/clock logic in backend — it only signals "DB is unreachable".
+- `DbException` is the right base class (covers Npgsql without importing it directly).
+- `OnTokenValidated` also hits the DB for the SecurityStamp check → throws `DbException`,
+  so the same 503 path covers it.
+
+### Frontend
+- `apiFetch` in `src/lib/api.ts` checks for 503 before the existing 401 check.
+- On 503, compare the browser clock to the maintenance window:
+  - In window → throw `MaintenanceError` with the maintenance message.
+  - Outside window → throw `ApiError` (status 503) with a generic "try again" message.
+- Uses `Intl.DateTimeFormat` to read the current hour in the window's timezone —
+  handles DST automatically.
+
+### UI error display
+- No global toast/error provider — errors are handled per-component.
+- `MaintenanceError` is checked with `instanceof` where errors render:
+  `JobTable`, `JobDetailPage`, `DocumentList`, `LoginPage`.
+- Future: migrate to a `QueryCache` global `onError` (one handler for all query errors;
+  `MutationCache` needs separate handling; requires a context provider or module-level
+  signal for global UI state).
+
+### Health check
+- `/health` already returns 503 when the DB is down (`AddDbContextCheck`) — no change needed.

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -98,7 +98,7 @@ All planned steps complete. See `docs/plans/demo-auth-features.md` for full deta
 | Kanban DragOverlay refactor | `DragOverlay` portal; `KanbanCardPreview` clone; `draggingId` state for clean post-drop transition |
 | AI access admin | `Admin` + `AiUser` roles; `AdminController`; `/admin` page |
 | Auto-fill parsing | `ParseListingDialog`; Claude Haiku; `POST /api/jobs/parse`; 2/min rate limit |
-| RDS maintenance window | EventBridge stops DB 00:00–08:00 AEST; backend 503 on `DbException`; frontend `MaintenanceError` with time-aware message |
+| RDS maintenance window | EventBridge stops DB 20:00–07:00 NZ; backend 503 on `DbException`; frontend `MaintenanceError` with time-aware message |
 | Company Verification API | External repo; live at `https://company-verification.onrender.com`; NZ + AU registries; not yet integrated into this project |
 | Dark mode + custom themes | Dark/light toggle in NavBar; 4 color themes (blue, red, yellow, pink); applied via `.theme-*` on `<html>`; stored in `UserPreferences.theme` |
 | Assessment + Withdrawn statuses | New enum values 7/8; auto-fill `appliedAt` on POST (non-Wishlist) and PATCH (→ Applied); confirm dialog when status changes to Applied and `appliedAt` already set (`JobEditSheet` + `KanbanBoard`); `ConfirmDialog` generic base + `DeleteConfirmDialog` wrapper in `ui/`; Kanban column order and tab filters updated |
@@ -117,4 +117,5 @@ All planned steps complete. See `docs/plans/demo-auth-features.md` for full deta
 | Job application rating API | Crowdsourced company ratings; separate product; scoring weights not finalized | Early planning |
 | Table scroll accessibility | Viewport-contained flex chain; `table-plain.tsx`; sticky `TableHeader`; see `docs/plans/table-scroll-accessibility.md` | Done |
 | Action bar layout fix | Move "Add New Job" + "Show/Hide Columns" into the view toggle row (`JobPage.tsx`) so they anchor to window edge — prevents clipping on narrow viewports; requires lifting add-job dialog trigger out of `JobTable` | Pending |
+| Maintenance page | Redirect to `/maintenance` on in-window 503; health-poll auto-recovery; see `docs/plans/maintenance-page.md` | Done |
 | — | View toggle + column selector polish | `IconToggle.tsx`: pill shape, animated check, blue active state. `ColumnToggle`: `Settings2` icon-only, `w-auto` popover, right-edge aligned, always-below, viewport-aware scroll | Done |

--- a/job-tracker-ui/nginx.conf
+++ b/job-tracker-ui/nginx.conf
@@ -79,4 +79,13 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
     }
+
+    # Proxied separately — without this, /health falls through to the SPA fallback and returns index.html.
+    location /health {
+        proxy_pass http://backend:8080/health;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
 }

--- a/job-tracker-ui/src/App.tsx
+++ b/job-tracker-ui/src/App.tsx
@@ -16,6 +16,7 @@ import RegisterPage from "./pages/RegisterPage"
 import SettingsPage from "./pages/SettingsPage"
 import DashboardPage from "./pages/DashboardPage"
 import ProfilePage from "./pages/ProfilePage"
+import MaintenancePage from "./pages/MaintenancePage"
 
 function App() {
   // the gate. React re-renders when state changes
@@ -41,6 +42,7 @@ function App() {
       <Route path="/confirm-email" element={<ConfirmEmailPage />} />
       <Route path="/forgot-password" element={<ForgotPasswordPage />} />
       <Route path="/reset-password" element={<ResetPasswordPage />} />
+      <Route path="/maintenance" element={<MaintenancePage />} />
       <Route path="/jobs" element={<ProtectedRoute><JobPage /></ProtectedRoute>} />
       <Route path="/jobs/:id" element={<ProtectedRoute><JobDetailPage /></ProtectedRoute>} />
       <Route path="/settings" element={<ProtectedRoute><SettingsPage /></ProtectedRoute>} />

--- a/job-tracker-ui/src/components/DocumentList.tsx
+++ b/job-tracker-ui/src/components/DocumentList.tsx
@@ -2,7 +2,7 @@ import { ResponsiveButton } from "@/components/ui/ResponsiveButton"
 import { DocumentCard } from "@/components/DocumentCard"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { useCreateDocument, useDocuments } from "@/hooks/documentQuery"
-import { ApiError, MaintenanceError } from "@/lib/api"
+import { ApiError } from "@/lib/api"
 import type { DocumentType } from "@/types/enums"
 import { Plus } from "lucide-react"
 import { useRef, useState } from "react"
@@ -26,7 +26,7 @@ export function DocumentList({ jobId }: DocumentListProps) {
       {
         onSuccess: () => setUploadError(null),
         onError: (err) => setUploadError(
-          err instanceof MaintenanceError || err instanceof ApiError ? err.message : "Failed to upload document."
+          err instanceof ApiError ? err.message : "Failed to upload document."
         )
       }
     )
@@ -34,7 +34,7 @@ export function DocumentList({ jobId }: DocumentListProps) {
   }
 
   if (isPending) return <p>Loading documents...</p>
-  if (isError) return <p>{error instanceof MaintenanceError ? error.message : "Failed to load documents."}</p>
+  if (isError) return <p>Failed to load documents.</p>
 
   return (
     <div className="space-y-4">

--- a/job-tracker-ui/src/components/DocumentList.tsx
+++ b/job-tracker-ui/src/components/DocumentList.tsx
@@ -12,7 +12,7 @@ interface DocumentListProps {
 }
 
 export function DocumentList({ jobId }: DocumentListProps) {
-  const { data: documents, isPending, isError, error } = useDocuments(jobId)
+  const { data: documents, isPending, isError } = useDocuments(jobId)
   const { mutate: addDocument, isPending: isUploading } = useCreateDocument()
   const [selectedType, setSelectedType] = useState<DocumentType>("Other")
   const [uploadError, setUploadError] = useState<string | null>(null)

--- a/job-tracker-ui/src/components/JobTable.tsx
+++ b/job-tracker-ui/src/components/JobTable.tsx
@@ -16,7 +16,6 @@ import {
 import { useJobs } from "@/hooks/jobQuery";
 import { useJobFilters, type SortField } from "@/hooks/useJobFilters";
 import { usePreferences } from "@/hooks/preferencesQuery";
-import { MaintenanceError } from "@/lib/api";
 import { COLUMNS } from "@/lib/columns";
 import type { ColumnKey } from "@/lib/columns";
 import { cn } from "@/lib/utils";
@@ -283,7 +282,7 @@ export function JobTable() {
   } = useJobFilters(tabFilteredJobs);
 
   if (isPending) return <p>Loading...</p>;
-  if (isError) return <p>{error instanceof MaintenanceError ? error.message : "Something went wrong."}</p>;
+  if (isError) return <p>Something went wrong.</p>;
 
   // Opens dialog for AI users with auto-fill on; otherwise opens sheet directly
   function handleAddJob() {

--- a/job-tracker-ui/src/components/JobTable.tsx
+++ b/job-tracker-ui/src/components/JobTable.tsx
@@ -214,7 +214,7 @@ const TAB_STYLES = {
 } as const;
 
 export function JobTable() {
-  const { data: jobs, isPending, isError, error } = useJobs();
+  const { data: jobs, isPending, isError } = useJobs();
   // AI users see ParseListingDialog first, non-AI sers see JobCreateSheet directly
   const [parseOpen, setParseOpen] = useState(false);
   const [sheetOpen, setSheetOpen] = useState(false);

--- a/job-tracker-ui/src/components/KanbanBoard.tsx
+++ b/job-tracker-ui/src/components/KanbanBoard.tsx
@@ -120,7 +120,7 @@ function KanbanColumn({ status, jobs, draggingId, confirmJobId }: { status: JobS
 }
 
 export function KanbanBoard() {
-  const { data: jobs, isPending, isError, error } = useJobs()
+  const { data: jobs, isPending, isError } = useJobs()
   const { mutate: patchJob } = usePatchJob()
   const sensors = useSensors(useSensor(PointerSensor))
   const [activeJob, setActiveJob] = useState<Job | null>(null)

--- a/job-tracker-ui/src/components/KanbanBoard.tsx
+++ b/job-tracker-ui/src/components/KanbanBoard.tsx
@@ -6,7 +6,6 @@ import { DndContext, DragOverlay, PointerSensor, useDraggable, useDroppable, use
 import type { DragEndEvent, DragStartEvent, Modifier } from '@dnd-kit/core'
 import { useNavigate } from 'react-router'
 import { useJobs, usePatchJob } from '@/hooks/jobQuery'
-import { MaintenanceError } from '@/lib/api'
 import { JobStatus } from '@/types/enums'
 import type { Job } from '@/types/job'
 import { PriorityDot } from '@/components/ui/PriorityDot'
@@ -174,7 +173,7 @@ export function KanbanBoard() {
   }
 
   if (isPending) return <p>Loading...</p>
-  if (isError) return <p>{error instanceof MaintenanceError ? error.message : 'Something went wrong.'}</p>
+  if (isError) return <p>Something went wrong.</p>
 
   return (
     <DndContext sensors={sensors} modifiers={[restrictToWindowEdges]} onDragStart={handleDragStart} onDragEnd={handleDragEnd}>

--- a/job-tracker-ui/src/lib/api.ts
+++ b/job-tracker-ui/src/lib/api.ts
@@ -29,19 +29,24 @@ export async function silentRefresh(): Promise<string> {
   return refreshPromise
 }
 
-const MAINTENANCE_WINDOW = { startHour: 0, endHour: 8, timezone: "Australia/Sydney" }
+const MAINTENANCE_WINDOW = { startHour: 20, endHour: 7, timezone: "Pacific/Auckland" }
 
-// Returns true if the current time in Sydney falls within the scheduled maintenance window
+// Returns true if the current NZ time falls within the scheduled maintenance window.
+// The window crosses midnight (20:00 → 07:00), so when startHour > endHour the check
+// is an OR: "after start OR before end". Matches the DST-aware EventBridge RDS schedule.
 function isMaintenanceWindow(): boolean {
   const hour = parseInt(
     new Intl.DateTimeFormat("en-AU", {
       timeZone: MAINTENANCE_WINDOW.timezone,
       hour: "numeric",
-      hour12: false,
+      hourCycle: "h23",
     }).format(new Date()),
     10
   )
-  return hour >= MAINTENANCE_WINDOW.startHour && hour < MAINTENANCE_WINDOW.endHour
+  const { startHour, endHour } = MAINTENANCE_WINDOW
+  return startHour <= endHour
+    ? hour >= startHour && hour < endHour
+    : hour >= startHour || hour < endHour
 }
 
 /**
@@ -110,10 +115,10 @@ export class ApiError extends Error {
 }
 
 /**
- * Thrown when a 503 response is received during the scheduled maintenance window (midnight–8 AM Sydney time).
+ * Thrown when a 503 response is received during the scheduled maintenance window (8 PM–7 AM New Zealand time).
  */
 export class MaintenanceError extends Error {
-  constructor(message = "Service is in maintenance (midnight–8 AM Sydney time). Please try again later.") {
+  constructor(message = "Service is in maintenance (8 PM–7 AM New Zealand time). Please try again later.") {
     super(message)
     this.name = "MaintenanceError"
   }

--- a/job-tracker-ui/src/lib/api.ts
+++ b/job-tracker-ui/src/lib/api.ts
@@ -73,7 +73,10 @@ export async function apiFetch(
 
   // 503 — DB unreachable, show maintenance message if within scheduled window
   if (response.status === 503) {
-    if (isMaintenanceWindow()) throw new MaintenanceError()
+    if (isMaintenanceWindow()) {
+      window.location.href = "/maintenance"
+      throw new MaintenanceError()
+    }
     throw new ApiError(503, "Service temporarily unavailable. Please try again.")
   }
 

--- a/job-tracker-ui/src/pages/JobDetailPage.tsx
+++ b/job-tracker-ui/src/pages/JobDetailPage.tsx
@@ -15,7 +15,6 @@ import { DocumentList } from "@/components/DocumentList";
 import { JobEditSheet } from "@/components/JobEditSheet";
 import { JobHeader } from "@/components/JobHeader";
 import { JobInfoCard } from "@/components/JobInfoCard";
-import { MaintenanceError } from "@/lib/api";
 import { useJob } from "@/hooks/jobQuery";
 import { useState } from "react";
 import NavBar from "@/components/NavBar";
@@ -31,7 +30,7 @@ function JobDetailPage() {
   const { data: job, isPending, isError, error } = useJob(jobId, { enabled: !isNaN(jobId) })
   if (!id || isNaN(jobId)) return <p>Invalid job ID.</p>
   if (isPending) return <p>Loading...</p>
-  if (isError) return <p>{error instanceof MaintenanceError ? error.message : "Something went wrong."}</p>
+  if (isError) return <p>Something went wrong.</p>
   if (!job) return <p>Job not found.</p>
 
   return (

--- a/job-tracker-ui/src/pages/JobDetailPage.tsx
+++ b/job-tracker-ui/src/pages/JobDetailPage.tsx
@@ -27,7 +27,7 @@ function JobDetailPage() {
 
   const { id } = useParams()
   const jobId = id ? parseInt(id) : NaN
-  const { data: job, isPending, isError, error } = useJob(jobId, { enabled: !isNaN(jobId) })
+  const { data: job, isPending, isError } = useJob(jobId, { enabled: !isNaN(jobId) })
   if (!id || isNaN(jobId)) return <p>Invalid job ID.</p>
   if (isPending) return <p>Loading...</p>
   if (isError) return <p>Something went wrong.</p>

--- a/job-tracker-ui/src/pages/LoginPage.tsx
+++ b/job-tracker-ui/src/pages/LoginPage.tsx
@@ -2,7 +2,7 @@ import AuthBrand from "@/components/AuthBrand"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
-import { ApiError, MaintenanceError } from "@/lib/api"
+import { ApiError } from "@/lib/api"
 import { login, loginDemo } from "@/services/authService"
 import { useState } from "react"
 import { Link, useNavigate } from "react-router"
@@ -24,7 +24,7 @@ export default function LoginPage() {
       await loginDemo()
       navigate("/jobs")
     } catch (err) {
-      setError(err instanceof MaintenanceError ? err.message : "Demo login failed. Please try again.")
+      setError("Demo login failed. Please try again.")
     } finally {
       setDemoLoading(false)
     }
@@ -43,9 +43,7 @@ export default function LoginPage() {
           await login(email, password)
           navigate("/jobs")
         } catch (err) {
-          if (err instanceof MaintenanceError) {
-            setError(err.message)
-          } else if (err instanceof ApiError) {
+          if (err instanceof ApiError) {
             if (err.status === 403) {
               setUnverified(true)
               setError(err.message)

--- a/job-tracker-ui/src/pages/MaintenancePage.tsx
+++ b/job-tracker-ui/src/pages/MaintenancePage.tsx
@@ -1,0 +1,50 @@
+// Maintenance page — shown when the DB is down during the scheduled window.
+import { useCallback, useEffect, useState } from "react"
+import { useNavigate } from "react-router"
+import { Loader2 } from "lucide-react"
+import { Button } from "@/components/ui/button"
+
+// /health lives at the backend root, not under /api — strip the trailing /api segment.
+const HEALTH_URL = (import.meta.env.VITE_API_BASE_URL as string).replace(/\/api$/, "") + "/health"
+const POLL_MS = 30_000
+
+export default function MaintenancePage() {
+  const navigate = useNavigate()
+  const [checking, setChecking] = useState(false)
+
+  // Plain fetch — apiFetch would loop (503 → redirect here → poll → 503 → …).
+  const check = useCallback(async () => {
+    try {
+      const res = await fetch(HEALTH_URL)
+      if (res.ok) navigate("/")
+    } catch { /* network error — still down, next poll will retry */ }
+  }, [navigate])
+
+  useEffect(() => {
+    const id = setInterval(check, POLL_MS)
+    return () => clearInterval(id)
+  }, [check])
+
+  async function handleRetry() {
+    setChecking(true)
+    await check()
+    setChecking(false)
+  }
+
+  return (
+    <div className="min-h-screen bg-muted flex flex-col items-center justify-center gap-6 px-6">
+      <div className="text-center max-w-md space-y-3">
+        <h1 className="text-xl font-semibold">Down for maintenance</h1>
+        <p className="text-sm text-muted-foreground">
+          The app is offline for scheduled maintenance (8 PM – 7 AM New Zealand time).
+          It will come back online automatically.
+        </p>
+        <p className="text-xs text-muted-foreground">Checking every 30 seconds…</p>
+      </div>
+      <Button onClick={handleRetry} disabled={checking}>
+        {checking && <Loader2 className="h-4 w-4 animate-spin" />}
+        Try again
+      </Button>
+    </div>
+  )
+}

--- a/job-tracker-ui/src/pages/MaintenancePage.tsx
+++ b/job-tracker-ui/src/pages/MaintenancePage.tsx
@@ -1,12 +1,12 @@
 // Maintenance page — shown when the DB is down during the scheduled window.
 import { useCallback, useEffect, useState } from "react"
 import { useNavigate } from "react-router"
-import { Loader2 } from "lucide-react"
+import { Loader2, MoonStar } from "lucide-react"
 import { Button } from "@/components/ui/button"
 
 // /health lives at the backend root, not under /api — strip the trailing /api segment.
 const HEALTH_URL = (import.meta.env.VITE_API_BASE_URL as string).replace(/\/api$/, "") + "/health"
-const POLL_MS = 30_000
+const POLL_MS = 60_000
 
 export default function MaintenancePage() {
   const navigate = useNavigate()
@@ -32,19 +32,28 @@ export default function MaintenancePage() {
   }
 
   return (
-    <div className="min-h-screen bg-muted flex flex-col items-center justify-center gap-6 px-6">
-      <div className="text-center max-w-md space-y-3">
-        <h1 className="text-xl font-semibold">Down for maintenance</h1>
-        <p className="text-sm text-muted-foreground">
-          The app is offline for scheduled maintenance (8 PM – 7 AM New Zealand time).
-          It will come back online automatically.
-        </p>
-        <p className="text-xs text-muted-foreground">Checking every 30 seconds…</p>
+    <div className="min-h-screen bg-muted flex items-center justify-center px-6">
+      <div className="bg-card rounded-2xl shadow-md p-10 max-w-md w-full flex flex-col items-center gap-6 text-center">
+        <div className="bg-muted rounded-full p-4">
+          <MoonStar className="h-10 w-10 text-muted-foreground" />
+        </div>
+        <div className="space-y-3">
+          <h1 className="text-2xl font-semibold">Away for the night</h1>
+          <p className="text-base text-muted-foreground">
+            The app pauses during low-traffic hours{" "}
+            <span className="whitespace-nowrap">(8 PM – 7 AM New Zealand time)</span>{" "}
+            to reduce costs.
+          </p>
+          <p className="text-base text-muted-foreground">
+            It restarts automatically each morning.
+          </p>
+          <p className="text-xs text-muted-foreground">Checking every minute…</p>
+        </div>
+        <Button onClick={handleRetry} disabled={checking}>
+          {checking && <Loader2 className="h-4 w-4 animate-spin" />}
+          Try again
+        </Button>
       </div>
-      <Button onClick={handleRetry} disabled={checking}>
-        {checking && <Loader2 className="h-4 w-4 animate-spin" />}
-        Try again
-      </Button>
     </div>
   )
 }


### PR DESCRIPTION
This pull request completes the implementation of a scheduled nightly RDS maintenance window and introduces a new `/maintenance` page for improved user experience during downtime. The frontend now redirects users to this page if the database is unavailable during the scheduled window, and auto-recovers when the service returns. It also removes now-obsolete per-component maintenance error handling. Documentation and configuration files have been updated to reflect the new NZ timezone window and the improved maintenance flow.

**Maintenance window and error handling updates:**

* The RDS maintenance window is now 20:00–07:00 NZ time (was 00:00–08:00 Sydney), with all references and documentation updated accordingly. [[1]](diffhunk://#diff-e2c3d757145eded1013e30e308b247c8f0aa603ccf3008633718e7c43f51d24cL4-R23) [[2]](diffhunk://#diff-378b8e52823d637f240b08446ef15475f13745a2cabebff169eb567074cba6b3L101-R101)
* The frontend intercepts 503 errors in `apiFetch` during the maintenance window and redirects users to a new `/maintenance` route, which polls the backend health endpoint and auto-recovers when the DB is back up. [[1]](diffhunk://#diff-0960cfd2e72ee384ff98c982ac70718fd7cc7898f4c6763207083fb53e39243aR1-R30) [[2]](diffhunk://#diff-45c7bd52b1c71b81846ae1df8ce86c8b98b088f3d0cd359633b0ab14243cafdaR19) [[3]](diffhunk://#diff-45c7bd52b1c71b81846ae1df8ce86c8b98b088f3d0cd359633b0ab14243cafdaR45)
* Per-component checks for `MaintenanceError` have been removed from `JobTable`, `KanbanBoard`, `DocumentList`, and related components; generic error messages are now shown outside the maintenance window. [[1]](diffhunk://#diff-d62d9aae313070a906548800f14309c6150f106871ed74c03014a29c91d785f9L5-R5) [[2]](diffhunk://#diff-d62d9aae313070a906548800f14309c6150f106871ed74c03014a29c91d785f9L15-R15) [[3]](diffhunk://#diff-d62d9aae313070a906548800f14309c6150f106871ed74c03014a29c91d785f9L29-R37) [[4]](diffhunk://#diff-7bceb6509ca39c7f56f6499dffe0aa8bae67b391bd3004dd0d8beae2a8895689L19) [[5]](diffhunk://#diff-7bceb6509ca39c7f56f6499dffe0aa8bae67b391bd3004dd0d8beae2a8895689L218-R217) [[6]](diffhunk://#diff-7bceb6509ca39c7f56f6499dffe0aa8bae67b391bd3004dd0d8beae2a8895689L286-R285) [[7]](diffhunk://#diff-b23b2f039bc2f44c07a74105a37a628cc94e677fc1b129cf2c92e63ebfaab489L9) [[8]](diffhunk://#diff-b23b2f039bc2f44c07a74105a37a628cc94e677fc1b129cf2c92e63ebfaab489L124-R123) [[9]](diffhunk://#diff-b23b2f039bc2f44c07a74105a37a628cc94e677fc1b129cf2c92e63ebfaab489L177-R176)

**Documentation and configuration:**

* Added `docs/plans/maintenance-page.md` detailing the new maintenance page, redirect logic, and health check polling.
* Updated `docs/plans/rds-maintenance-window.md` to clarify the new NZ-based schedule, DST handling, and the simplified error handling flow. [[1]](diffhunk://#diff-e2c3d757145eded1013e30e308b247c8f0aa603ccf3008633718e7c43f51d24cL4-R23) [[2]](diffhunk://#diff-e2c3d757145eded1013e30e308b247c8f0aa603ccf3008633718e7c43f51d24cL88-R76)
* Updated `docs/progress.md` to mark the maintenance page as complete and to reflect the new maintenance window. [[1]](diffhunk://#diff-378b8e52823d637f240b08446ef15475f13745a2cabebff169eb567074cba6b3L101-R101) [[2]](diffhunk://#diff-378b8e52823d637f240b08446ef15475f13745a2cabebff169eb567074cba6b3R120)
* Updated `CLAUDE.md` to document the new maintenance window and error handling logic.
* Updated `nginx.conf` to proxy `/health` requests to the backend, ensuring the health endpoint works during downtime.