### PR TITLE
Feat/profile analysis

### DIFF
--- a/JobTrackerApi/Program.cs
+++ b/JobTrackerApi/Program.cs
@@ -306,7 +306,7 @@ app.UseExceptionHandler(errorApp =>
             // Walk the whole chain: EF Core wraps a DB connection failure in a non-DbException,
             // so the DbException is nested, not top-level. See docs/plans/maintenance-page.md.
             var isDbDown = false;
-            for (var e = error.Error; e is not null; e = e.InnerException)
+            for (Exception? e = error.Error; e is not null; e = e.InnerException)
             {
                 if (e is System.Data.Common.DbException)
                 {

--- a/JobTrackerApi/Program.cs
+++ b/JobTrackerApi/Program.cs
@@ -303,7 +303,19 @@ app.UseExceptionHandler(errorApp =>
 
         if (error != null)
         {
-            if (error.Error is System.Data.Common.DbException)
+            // Walk the whole chain: EF Core wraps a DB connection failure in a non-DbException,
+            // so the DbException is nested, not top-level. See docs/plans/maintenance-page.md.
+            var isDbDown = false;
+            for (var e = error.Error; e is not null; e = e.InnerException)
+            {
+                if (e is System.Data.Common.DbException)
+                {
+                    isDbDown = true;
+                    break;
+                }
+            }
+
+            if (isDbDown)
             {
                 // DbException includes intentional maintenance window downtime
                 logger.LogError(error.Error, "Database unavailable");

--- a/docs/plans/maintenance-page.md
+++ b/docs/plans/maintenance-page.md
@@ -29,20 +29,9 @@ When the DB is down during the scheduled window, redirect users to a dedicated
 - CORS not needed in prod — same domain through Nginx. Dev uses existing `DevCors` policy.
 - Verified working in dev. Health returns 503 while DB down, 200 when up (`AddDbContextCheck`).
 
-## Post-deploy bugs (found 2026-07 in a real maintenance window)
+## Post-deploy fixes (a real maintenance window exposed three gaps)
 
-### Bug 1 — login showed "Unknown error", not the maintenance page
-- Symptom: during RDS downtime `POST /api/auth/login` returned **500**, not 503, so `apiFetch`'s in-window 503 → `/maintenance` branch never fired; the `{ error }` body also isn't understood by `throwApiError`, degrading to "Unknown error".
-- Root cause: `UseNpgsql` has no `EnableRetryOnFailure`, so EF Core's execution strategy wraps a connection failure in a top-level `System.InvalidOperationException` ("...likely due to a transient failure"). The real `NpgsqlException` (a `System.Data.Common.DbException`) is nested in `InnerException`, so the old top-level `error.Error is DbException` check missed it and fell through to the generic 500.
-- Why `/health` still worked: `AddDbContextCheck` reports Unhealthy → 503 correctly; only the request path mislabelled the outage, which is why maintenance-page polling recovered but login didn't.
-- Fix (Option A): the exception handler walks the whole `InnerException` chain for `DbException`. `NpgsqlException` is always in the chain for a connect failure, so this catches both wrapped and unwrapped cases. Done (`Program.cs`).
-
-Verified against official sources:
-- Npgsql: `NpgsqlException` subclasses `System.Data.DbException`; network errors raise an `NpgsqlException` wrapping an `IOException`/`SocketException` — [exceptions doc](https://www.npgsql.org/doc/diagnostics/exceptions_notices.html), [NpgsqlException API](https://www.npgsql.org/doc/api/Npgsql.NpgsqlException.html).
-- EF Core (no retry) re-wraps a transient connect failure in `InvalidOperationException` — reproduced stack in [npgsql#5183](https://github.com/npgsql/npgsql/issues/5183), behaviour in [efcore#11303](https://github.com/dotnet/efcore/issues/11303).
-
-### Bug 2 — cold load bounces logged-in users to `/login`, not `/maintenance`
-- Symptom: opening the app during downtime lands on `/login` instead of `/maintenance`.
-- Root cause: `App.tsx` → `silentRefresh` uses plain `fetch` and has no maintenance handling; on refresh failure it just clears the init gate, so `ProtectedRoute` redirects to `/login`. The `/maintenance` redirect lives only in `apiFetch`, which the cold-load refresh bypasses. (Fix #1's backend 503 doesn't help here — `silentRefresh` ignores the status.)
-- Fix: `silentRefresh` now detects an in-window 503 and redirects to `/maintenance`. Guarded by `pathname !== "/maintenance"` because `App.tsx` runs `silentRefresh` on every mount, so an unguarded redirect would reload-loop on the maintenance page itself. Also covers `apiFetch`'s 401-retry path, which shares `silentRefresh`. Done (`api.ts`).
-- Defensive follow-up: `throwApiError` should read the `{ error }` body field so a DB-down response never degrades to "Unknown error". Pending.
+- **DB-down returned 500, not 503.** With no `EnableRetryOnFailure` on `UseNpgsql`, EF Core wraps a connection failure in a top-level `InvalidOperationException`; the `NpgsqlException` (a `DbException`) is nested in `InnerException`, so the old top-level `is DbException` check missed it. Fix: the exception handler walks the whole `InnerException` chain for `DbException` (`Program.cs`). `/health` (`AddDbContextCheck`) already returned 503 correctly — only the request path mislabelled the outage.
+  - Refs: [Npgsql exceptions](https://www.npgsql.org/doc/diagnostics/exceptions_notices.html) (`NpgsqlException : DbException`); [npgsql#5183](https://github.com/npgsql/npgsql/issues/5183) / [efcore#11303](https://github.com/dotnet/efcore/issues/11303) (EF wraps transient connect failures).
+- **Cold load bounced users to `/login`, not `/maintenance`.** `silentRefresh` bypasses `apiFetch` (the only place with the 503 redirect). Fix: `silentRefresh` redirects to `/maintenance` on an in-window 503, guarded by `pathname !== "/maintenance"` — it runs on every `App.tsx` mount, so an unguarded redirect reload-loops on the maintenance page. Also covers `apiFetch`'s 401-retry path (`api.ts`).
+- **Generic errors showed "Unknown error".** Fix: `throwApiError` falls back to a client-authored, status-based message (`genericFallbackMessage`). It deliberately does **not** echo the backend's `{ error }` field — that's the generic/untrusted channel (info-disclosure boundary); controlled `message`/`description[]` are still shown verbatim (`api.ts`).

--- a/docs/plans/maintenance-page.md
+++ b/docs/plans/maintenance-page.md
@@ -28,3 +28,21 @@ When the DB is down during the scheduled window, redirect users to a dedicated
 - `HEALTH_URL` in `MaintenancePage.tsx` strips `/api` from `VITE_API_BASE_URL` and appends `/health` — works in dev (hits ASP.NET directly) and prod (hits Nginx → proxied to backend).
 - CORS not needed in prod — same domain through Nginx. Dev uses existing `DevCors` policy.
 - Verified working in dev. Health returns 503 while DB down, 200 when up (`AddDbContextCheck`).
+
+## Post-deploy bugs (found 2026-07 in a real maintenance window)
+
+### Bug 1 — login showed "Unknown error", not the maintenance page
+- Symptom: during RDS downtime `POST /api/auth/login` returned **500**, not 503, so `apiFetch`'s in-window 503 → `/maintenance` branch never fired; the `{ error }` body also isn't understood by `throwApiError`, degrading to "Unknown error".
+- Root cause: `UseNpgsql` has no `EnableRetryOnFailure`, so EF Core's execution strategy wraps a connection failure in a top-level `System.InvalidOperationException` ("...likely due to a transient failure"). The real `NpgsqlException` (a `System.Data.Common.DbException`) is nested in `InnerException`, so the old top-level `error.Error is DbException` check missed it and fell through to the generic 500.
+- Why `/health` still worked: `AddDbContextCheck` reports Unhealthy → 503 correctly; only the request path mislabelled the outage, which is why maintenance-page polling recovered but login didn't.
+- Fix (Option A): the exception handler walks the whole `InnerException` chain for `DbException`. `NpgsqlException` is always in the chain for a connect failure, so this catches both wrapped and unwrapped cases. Done (`Program.cs`).
+
+Verified against official sources:
+- Npgsql: `NpgsqlException` subclasses `System.Data.DbException`; network errors raise an `NpgsqlException` wrapping an `IOException`/`SocketException` — [exceptions doc](https://www.npgsql.org/doc/diagnostics/exceptions_notices.html), [NpgsqlException API](https://www.npgsql.org/doc/api/Npgsql.NpgsqlException.html).
+- EF Core (no retry) re-wraps a transient connect failure in `InvalidOperationException` — reproduced stack in [npgsql#5183](https://github.com/npgsql/npgsql/issues/5183), behaviour in [efcore#11303](https://github.com/dotnet/efcore/issues/11303).
+
+### Bug 2 — cold load bounces logged-in users to `/login`, not `/maintenance`
+- Symptom: opening the app during downtime lands on `/login` instead of `/maintenance`.
+- Root cause: `App.tsx` → `silentRefresh` uses plain `fetch` and has no maintenance handling; on refresh failure it just clears the init gate, so `ProtectedRoute` redirects to `/login`. The `/maintenance` redirect lives only in `apiFetch`, which the cold-load refresh bypasses. (Fix #1's backend 503 doesn't help here — `silentRefresh` ignores the status.)
+- Fix: `silentRefresh` now detects an in-window 503 and redirects to `/maintenance`. Guarded by `pathname !== "/maintenance"` because `App.tsx` runs `silentRefresh` on every mount, so an unguarded redirect would reload-loop on the maintenance page itself. Also covers `apiFetch`'s 401-retry path, which shares `silentRefresh`. Done (`api.ts`).
+- Defensive follow-up: `throwApiError` should read the `{ error }` body field so a DB-down response never degrades to "Unknown error". Pending.

--- a/job-tracker-ui/src/lib/api.ts
+++ b/job-tracker-ui/src/lib/api.ts
@@ -139,6 +139,13 @@ export class MaintenanceError extends Error {
 }
 
 
+// Never echo the backend's { error } field (untrusted channel — could leak server detail);
+// return a safe client-authored fallback instead. See docs/plans/maintenance-page.md.
+function genericFallbackMessage(status: number): string {
+  if (status >= 500) return "Something went wrong on our end. Please try again shortly."
+  return "Something went wrong. Please try again."
+}
+
 /**
  * Helper function to throw an ApiError with the status code and message from the response body if available.
  * @param response - The Response object returned from a fetch request.
@@ -159,7 +166,7 @@ async function throwApiError(response: Response): Promise<never> {
       ? body.map((e: { description?: string }) => e.description).filter(Boolean).join(". ")
       : null) ??
     (typeof body === "string" ? body : null) ??
-    "Unknown error"
+    genericFallbackMessage(response.status)
   )
 }
 

--- a/job-tracker-ui/src/lib/api.ts
+++ b/job-tracker-ui/src/lib/api.ts
@@ -17,6 +17,17 @@ export async function silentRefresh(): Promise<string> {
     credentials: "include",
   })
     .then(async (res) => {
+      // DB down during the scheduled window, route to the maintenance page instead of
+      // throwing (which would strand the user on /login). Skip when already on /maintenance:
+      // App.tsx runs silentRefresh on every mount, so redirecting there would reload-loop.
+      if (
+        res.status === 503 &&
+        isMaintenanceWindow() &&
+        window.location.pathname !== "/maintenance"
+      ) {
+        window.location.href = "/maintenance"
+        throw new MaintenanceError()
+      }
       if (!res.ok) throw new Error("Refresh failed")
       const data = await res.json()
       setToken(data.accessToken)


### PR DESCRIPTION
This pull request addresses several issues discovered during a real maintenance window, improving error handling and user experience when the database is down or other backend errors occur. The main changes ensure that database outages are correctly detected and reported, users are properly redirected to the maintenance page during downtime, and error messages are safer and more informative.

**Backend improvements:**

* The exception handler in `Program.cs` now walks the entire exception chain to detect `DbException`, ensuring database outages are correctly identified even when exceptions are nested.
* Documentation in `maintenance-page.md` was updated to explain the new error handling logic and other post-deploy fixes, including references to related issues and the rationale behind the changes.

**Frontend improvements:**

* `silentRefresh` in `api.ts` now redirects users to `/maintenance` during a scheduled maintenance window if a 503 error is received, preventing users from being stranded on the login page.
* A new `genericFallbackMessage` function provides safe, client-authored fallback error messages instead of echoing untrusted backend error fields, reducing the risk of information disclosure.
* The `throwApiError` helper now uses `genericFallbackMessage` for unknown errors, ensuring users see clear and secure error messages.