### PR TITLE
feat: add profile conditions and Claude-based job analysis service

### DIFF
--- a/.claude/hooks/coauthor-guard.sh
+++ b/.claude/hooks/coauthor-guard.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# PreToolUse hook (matcher: Bash): co-author guard.
+# Deny any Bash command that would put a Co-Authored-By trailer or a Claude
+# author identity into git history.
+#
+# Deny JSON on exit 0 blocks the command; silent exit defers to permission rules.
+
+cmd=$(jq -r '.tool_input.command // ""')
+
+# Case-insensitive, anywhere in the command string — not just git invocations,
+# so staging a trailer into a file for `git commit -F` is also caught.
+# Matches the trailer key and the Claude author identity (--author overrides).
+if printf '%s' "$cmd" | grep -qiE 'co-authored-by|noreply@anthropic\.com'; then
+  cat <<'JSON'
+{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Attribution policy: Claude must never appear as author, co-author, or contributor in git history. Remove the Co-Authored-By trailer / Claude author identity and retry. See CLAUDE.md (Attribution)."}}
+JSON
+fi

--- a/.claude/hooks/fetch-guard.sh
+++ b/.claude/hooks/fetch-guard.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# PreToolUse hook (matcher: Bash): fetch guard.
+# Allow exactly `git fetch origin main` (the settings.json allow rule runs it);
+# hard-deny every other git fetch form.
+#
+# Deny JSON on exit 0 blocks the command; silent exit defers to permission rules.
+
+cmd=$(jq -r '.tool_input.command // ""')
+
+# Byte-exact match only; spacing variants are deliberately denied below.
+if [ "$cmd" = "git fetch origin main" ]; then
+  exit 0
+fi
+
+# A git invocation whose subcommand is fetch, anywhere in the command string.
+# Each dash option between git and fetch may carry one separate argument token
+# (`git -C /tmp fetch`). "fetch" as a mere argument does not match
+# (`git add fetch.js`), but a quoted literal does (`git commit -m "git fetch"`)
+# — accepted trade-off; reword the string and retry.
+if printf '%s' "$cmd" | grep -qE '(^|[^[:alnum:]_./-])git([[:space:]]+-[^[:space:]]+([[:space:]]+[^-[:space:]][^[:space:]]*)?)*[[:space:]]+fetch([[:space:]]|$)'; then
+  cat <<'JSON'
+{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Fetch policy: only the exact command `git fetch origin main` is permitted; every other fetch form is blocked."}}
+JSON
+fi

--- a/.claude/hooks/gh-guard.sh
+++ b/.claude/hooks/gh-guard.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# PreToolUse hook (matcher: Bash): gh allowlist guard.
+# Default-deny for the GitHub CLI. Ten (group, verb) pairs may run with args:
+#   gh pr create|edit|list    gh issue create|edit|view
+#   gh label create|edit|list gh repo view
+# Plus one exact form with no flags or args: `gh issue list`.
+# Every other gh invocation — any other subcommand, any other group, an
+# extension, an alias, a future addition — is denied.
+#
+# Deny JSON on exit 0 blocks the command; silent exit defers to permission rules.
+
+cmd=$(jq -r '.tool_input.command // ""')
+
+# A gh invocation: `gh` at a word boundary, followed by whitespace or end.
+gh_present='(^|[^[:alnum:]_./-])gh([[:space:]]|$)'
+
+# An allowed gh invocation: gh, then optional global flags (each dash option may
+# carry one separate value token, so `gh -R owner/repo issue create` resolves to
+# `issue create`), then exactly one of the ten permitted group+verb pairs.
+gh_allowed='(^|[^[:alnum:]_./-])gh([[:space:]]+-[^[:space:]]+([[:space:]]+[^-[:space:]][^[:space:]]*)?)*[[:space:]]+(pr[[:space:]]+(create|edit|list)|issue[[:space:]]+(create|edit|view)|label[[:space:]]+(create|edit|list)|repo[[:space:]]+view)([[:space:]]|$)'
+
+# An exact `gh issue list` — no global flags, no args. Kept separate from the
+# pairs above (which allow trailing args) so a body/state dump such as
+# `gh issue list --json body --state all` stays denied: read-only titles only.
+gh_issue_list='(^|[^[:alnum:]_./-])gh[[:space:]]+issue[[:space:]]+list[[:space:]]*$'
+
+# Split at shell separators so each gh call is judged on its own; a gh call
+# inside $(...) or backticks is split out the same way.
+segments=$(printf '%s' "$cmd" | sed -E 's/(&&|\|\||;|\||`|\$\()/\n/g')
+
+deny=0
+while IFS= read -r seg; do
+  if printf '%s' "$seg" | grep -qE "$gh_present"; then
+    if ! printf '%s' "$seg" | grep -qE "$gh_allowed" && ! printf '%s' "$seg" | grep -qE "$gh_issue_list"; then
+      deny=1
+      break
+    fi
+  fi
+done <<EOF
+$segments
+EOF
+
+if [ "$deny" = 1 ]; then
+  cat <<'JSON'
+{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"gh allowlist: only these forms may run — gh pr create|edit|list, gh issue create|edit|view, gh label create|edit|list, gh repo view, and bare gh issue list (no flags or args). Every other gh command (other subcommands, other groups, extensions, aliases, gh issue list with any flag) is blocked. See CLAUDE.md."}}
+JSON
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,10 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "attribution": {
+    "commit": "",
+    "pr": "",
+    "sessionUrl": false
+  },
   "permissions": {
     "allow": [
       "Bash(git status)",
@@ -12,9 +17,28 @@
       "Bash(git commit *)"
     ],
     "deny": [
-      "Read(**/.env*)",
+      "Read(**/.env)",
+      "Read(**/.env.local)",
+      "Read(**/.env.development)",
+      "Read(**/.env.production)",
+      "Read(**/.env.staging)",
+      "Read(**/.env.test)",
+      "Read(**/.env.*.local)",
       "Read(**/appsettings.*.json)",
       "Read(**/*secret*)",
+      "Bash(git add .)",
+      "Bash(git add . *)",
+      "Bash(git add ./)",
+      "Bash(git add -A)",
+      "Bash(git add -A *)",
+      "Bash(git add --all)",
+      "Bash(git add --all *)",
+      "Bash(git add -u)",
+      "Bash(git add -u *)",
+      "Bash(git add --update)",
+      "Bash(git add --update *)",
+      "Bash(git add -f *)",
+      "Bash(git add --force *)",
       "Bash(git push *)",
       "Bash(git pull *)",
       "Bash(git fetch *)",
@@ -26,7 +50,58 @@
       "Bash(git clean *)",
       "Bash(git stash *)",
       "Bash(git branch *)",
-      "Bash(git tag *)"
+      "Bash(git tag *)",
+      "Bash(gh agent-task *)",
+      "Bash(gh alias *)",
+      "Bash(gh api *)",
+      "Bash(gh attestation *)",
+      "Bash(gh auth *)",
+      "Bash(gh browse *)",
+      "Bash(gh cache *)",
+      "Bash(gh co *)",
+      "Bash(gh codespace *)",
+      "Bash(gh completion *)",
+      "Bash(gh config *)",
+      "Bash(gh copilot *)",
+      "Bash(gh discussion *)",
+      "Bash(gh extension *)",
+      "Bash(gh gist *)",
+      "Bash(gh gpg-key *)",
+      "Bash(gh licenses *)",
+      "Bash(gh org *)",
+      "Bash(gh preview *)",
+      "Bash(gh project *)",
+      "Bash(gh release *)",
+      "Bash(gh ruleset *)",
+      "Bash(gh run *)",
+      "Bash(gh search *)",
+      "Bash(gh secret *)",
+      "Bash(gh skill *)",
+      "Bash(gh ssh-key *)",
+      "Bash(gh status *)",
+      "Bash(gh variable *)",
+      "Bash(gh workflow *)"
+    ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/fetch-guard.sh"
+          },
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/coauthor-guard.sh"
+          },
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/gh-guard.sh"
+          }
+        ]
+      }
     ]
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,11 +9,27 @@
     "allow": [
       "Bash(git status)",
       "Bash(git diff *)",
+      "Bash(git log *)",
+      "Bash(git show *)",
+      "Bash(git rev-parse *)",
+      "Bash(git ls-remote *)",
+      "Bash(git fetch origin main)",
+      "Bash(git add *)",
+      "Bash(gh pr create *)",
+      "Bash(gh pr edit *)",
+      "Bash(gh pr list *)",
+      "Bash(gh issue create *)",
+      "Bash(gh issue edit *)",
+      "Bash(gh issue view *)",
+      "Bash(gh issue list)",
+      "Bash(gh label create *)",
+      "Bash(gh label edit *)",
+      "Bash(gh label list *)",
+      "Bash(gh repo view *)",
       "Write(/.comment-audit/processed.json)",
       "Edit(/.comment-audit/processed.json)"
     ],
     "ask": [
-      "Bash(git add *)",
       "Bash(git commit *)"
     ],
     "deny": [
@@ -41,7 +57,6 @@
       "Bash(git add --force *)",
       "Bash(git push *)",
       "Bash(git pull *)",
-      "Bash(git fetch *)",
       "Bash(git checkout *)",
       "Bash(git switch *)",
       "Bash(git merge *)",

--- a/.claude/skills/git-commit/SKILL.md
+++ b/.claude/skills/git-commit/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: git-commit
+description: Use this skill whenever creating a git commit — when the user asks to commit, or when you are about to run `git commit` yourself. Commits locally only: never pushes, branches, or amends history.
+---
+
+# Git Commit
+
+Turn working-tree changes into one or more well-formed local commits.
+
+## Format — Conventional Commits
+
+Every summary line is:
+
+```
+<type>(<scope>): <summary>
+```
+
+- **type** (required): `feat`, `fix`, `docs`, `refactor`, `test`, `style`, `perf`, `build`, `ci`, `chore`.
+- **scope** (optional): the area touched, e.g. `feat(auth):`. Omit when it adds nothing.
+- **summary**: imperative mood ("add", not "added"/"adds"), lower-case, no trailing period. Aim ≤ 50 chars, hard limit 72.
+
+Body (optional, after a blank line): explain **why**, not what — the diff shows what. Wrap at 72 cols. Add one only when the reason isn't obvious from the summary.
+
+Breaking change: append `!` after the type/scope (`feat!:`) and add a `BREAKING CHANGE: <detail>` footer.
+
+## Commit boundaries — atomic
+
+- One logical change per commit. A commit may span several files when they serve the same change; it must never bundle unrelated changes.
+- Don't wait for the whole task to finish — commit each coherent unit (a feature, a logic section, a fix) as it lands.
+
+## Staging — explicit paths only
+
+- Stage the exact paths for the commit at hand: `git add <path> …`.
+- Never `git add .`, `-A`, or `-u` — they defeat atomic boundaries and are blocked by policy.
+
+## Issue references
+
+Reference issues in a footer line: `Refs #<n>` (related) or `Closes #<n>` (this commit resolves it).
+
+- **`feat` and `fix` require a reference.** Resolve the number in this order:
+  1. **Registry** — `issues.md` next to this skill. Match the work against a recorded title/description.
+  2. **`gh issue list`** (bare, no flags) — read the current open issues and match by title.
+  3. **Still nothing** — stop and ask the user to pick: give an existing number, create one first (hand off to `github-issue-creator` → `issue-publish`), or commit without a reference this once.
+- **Every other type**: add a reference when a matching issue is already known (registry or conversation); otherwise commit without one — don't go hunting.
+- Confirm an uncertain number with `gh issue view <n>` before writing it into a message.
+
+## Issue registry
+
+`issues.md` next to this skill is the local index of issues worth referencing — one row per issue: number · full title · one-line concise description. This skill owns it.
+
+- After using or learning a number that isn't listed yet — from the user, from a freshly published issue (`issue-publish` prints the new issue's URL; the number is its last path segment), or from `gh issue list` — append a row.
+- Treat the registry as a cache, not truth: it drifts as issues close, get renamed, or are opened on the web. When `gh issue list` disagrees, trust the live list and reconcile the row.
+- Only the bare `gh issue list` is permitted (no `--json`, `--state`, `--search`, or other flags — the guard denies them).
+
+## Attribution
+
+Never add a `Co-Authored-By` trailer or any Claude author identity to a commit — policy `docs/permissions/v3-no-coauthor.md`, enforced by a hook.
+
+## Words banned in message text
+
+`gh` + word · `Co-Authored-By` · `git fetch`
+
+## Procedure
+
+1. Survey the tree: `git status`, `git diff`, and `git diff --staged`.
+2. Group the changes into atomic commits; decide type/scope/summary for each.
+3. For any `feat`/`fix` without a known issue, run the issue-reference step above before committing.
+4. Per commit, in order: stage its exact paths, then `git commit`. Show the planned message before running it.
+5. Multi-line messages: pass repeated `-m` (`-m "<summary>" -m "<body>" -m "Refs #12"`) so no message file is needed.
+6. A commit body of more than a line goes through `human-writing`.
+7. After committing, report what landed (`git log --oneline -<n>`). Never push — leave the commits local for the user.

--- a/.claude/skills/git-commit/issues.md
+++ b/.claude/skills/git-commit/issues.md
@@ -1,0 +1,12 @@
+# Issue registry
+
+Local index of GitHub issues worth referencing from commits. Owned and
+maintained by the `git-commit` skill; the commit flow reads this first and
+falls back to bare `gh issue list`. A cache, not truth — reconcile against the
+live list when they disagree.
+
+One row per issue. Keep the description to one concise line.
+
+| # | Title | Description |
+|---|-------|-------------|
+| _(none yet)_ | | |

--- a/.claude/skills/github-issue-creator/SKILL.md
+++ b/.claude/skills/github-issue-creator/SKILL.md
@@ -1,27 +1,24 @@
 ---
 name: github-issue-creator
-description: Use this skill whenever the user wants to create a GitHub issue, write up a task or bug report for GitHub, or turn a conversation or rough explanation into a structured GitHub issue. Triggers include phrases like "make an issue", "create a GitHub issue", "write this up as an issue", "turn this into a ticket", "I need an issue for this", or any request that involves producing a title and body suitable for pasting into GitHub's issue form. Also trigger when the user describes a feature, bug, or task and asks you to formalize or structure it. This skill is GitHub-only. Do NOT use for Jira, Linear, Asana, or other issue trackers.
+description: Use this skill whenever the user wants to create a GitHub issue, write up a task or bug report for GitHub, or turn a conversation or rough explanation into a structured GitHub issue — including a described feature, bug, or task the user asks to formalize. Drafts only: writes a local draft file, never posts to GitHub, never runs `gh`.
 ---
 
 # GitHub Issue Creator
 
-Produce a GitHub issue draft from conversation context or rough input. This skill drafts only, it never posts to GitHub.
+Produce a GitHub issue draft from conversation context or rough input.
 
 ## Output
- 
-Write the draft to `.github/drafts/issue-draft.md`, overwriting any existing file at that path. Create the `.github/drafts/` directory if it does not exist. Always use this exact path and filename.
- 
-After writing the file, show the rendered draft in chat so the user can review without opening the file, and tell them the file path so they know where to copy from.
+
+Write the draft to `.github/drafts/issue-draft.md` — always this exact path — creating the directory if needed and overwriting any existing file.
 
 ## File format — follow this exactly
 
-The file has YAML frontmatter for the title followed by the issue body.
+The file has YAML frontmatter for the title and labels, followed by the issue body.
 
 ```markdown
 ---
 title: "feat: add bulk export for user activity logs"
-labels: []
-assignees: []
+labels: [feature]
 ---
  
 Allow admins to export user activity logs as CSV for compliance auditing. No current way to extract this data without direct DB access.
@@ -38,7 +35,17 @@ Allow admins to export user activity logs as CSV for compliance auditing. No cur
 ## Rules
 
 - Title: use `feat:`, `fix:`, `refactor:`, `docs:`, `chore:` prefix when obvious. Keep under 70 chars.
+- Labels: draw only from the preset `.claude/skills/label-setup/labels.yml` — never a label outside it. Keep the set small: usually one type label (e.g. `feature`, `bug`), optionally paired with one `priority:` label. Use an empty list when none apply.
 - Each checkbox = a coherent unit of work. Not micro-steps, not mega-tasks.
 - Keep checkboxes between 4–20. If exceeding 20, consolidate first. If still over 20, split into separate issues — produce the first one, suggest follow-up titles with one-line descriptions, and ask the user if they want those written out.
 - Add `### Context` or `### Notes` only when there's genuinely useful background. Otherwise omit entirely.
-- Never post to GitHub. Never run `gh`, `git`, or any network call. This skill only writes a local file.
+- Never post to GitHub; never run `gh`, `git`, or any network call.
+
+## After writing
+
+Do not render the draft in chat — the user reviews the file in their editor. Show the file path and ask them to choose:
+
+1. **Happy, publish** — hand off to the `issue-publish` skill.
+2. **Needs change** — revise the draft, rewrite the file, and ask again.
+3. **Happy, but don't publish now** — stop; the draft file stays for later.
+4. **Something else** — open-ended.

--- a/.claude/skills/issue-publish/SKILL.md
+++ b/.claude/skills/issue-publish/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: issue-publish
+description: >
+  Create or edit a GitHub issue with `gh` from the reviewed draft at
+  `.github/drafts/issue-draft.md`. Use only when that draft exists and the
+  user asks to publish, open, or file it — typically handed off from
+  `github-issue-creator`. Assigns the issue to the user; never comments,
+  closes, or reopens.
+---
+
+# Issue Publish
+
+Publish the issue draft by running the steps below in order.
+
+## Hard limits
+
+- GitHub issue writes only, and only `gh issue create` / `gh issue edit`. Never comment, close, or reopen an issue.
+- No git or codebase changes of any kind — the draft included. The only file you may write is the temporary body file in step 8.
+- Read-only `gh` for every precondition.
+
+## Read the draft
+
+1. Read `.github/drafts/issue-draft.md`. If it is missing, stop and tell the user to run `github-issue-creator` first.
+2. Parse the front-matter: `title`, `labels`. Everything after the closing `---` is the body. Use these values verbatim — never rewrite them.
+
+## Precondition
+
+3. Confirm the repo is reachable and `gh` is authenticated: `gh repo view`. If it fails, stop and tell the user to check the repo or run `gh auth login`.
+
+## Create vs edit
+
+4. **Create** unless the user named an existing issue number to update.
+5. **Edit** only when the user gave an issue number. First confirm it exists with `gh issue view <number>`; if that fails, stop rather than create a new issue by mistake.
+
+## Labels
+
+6. Fetch the repo's labels once: `gh label list --json name --limit 500`.
+7. Every label the draft names must already exist. If any is missing, stop, list the missing names, and tell the user to run `/label-setup` — never create labels.
+
+## Assemble, confirm, run
+
+8. Write the body to a temporary file outside the repo with `mktemp`. Pass it as `--body-file`.
+9. Assemble the exact command. Apply the constant the draft does not carry: `--assignee @me` on create.
+   - Create:
+     ```
+     gh issue create --title "<title>" --body-file <tmpfile> \
+       --assignee @me --label "<label>"   # repeat --label per label
+     ```
+   - Edit (assignee is not re-applied; add labels without removing any):
+     ```
+     gh issue edit <number> --title "<title>" --body-file <tmpfile> \
+       --add-label "<label>"   # repeat --add-label per label
+     ```
+10. Show the assembled command(s) in full and ask once for approval. Run nothing until the user approves.
+11. On approval, run the command, then delete the temporary body file. Report the issue URL `gh` prints.

--- a/.claude/skills/label-setup/SKILL.md
+++ b/.claude/skills/label-setup/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: label-setup
+description: >
+  Create or reconcile a repository's labels from the preset in `labels.yml`.
+  Writes labels only — never deletes, never touches labels outside the preset.
+  Invoke with /label-setup.
+disable-model-invocation: true
+---
+
+# Label Setup
+
+Bring the repository's labels into line with the preset in `labels.yml` by running the steps below in order.
+
+## Hard limits
+
+- Write labels only, and only with `gh label create` and `gh label edit`. Never run `gh label delete`.
+- Only preset names drive action. A repo label absent from `labels.yml` is left untouched.
+- The preset is read-only input: never edit `labels.yml`.
+- No git or codebase changes of any kind.
+
+## Preconditions
+
+1. Confirm the repo is reachable and `gh` is authenticated: `gh repo view`. If it fails, stop and tell the user to check the repo or run `gh auth login`.
+2. Read the preset from `labels.yml` beside this file. If it is missing or empty, stop.
+
+## Plan the changes
+
+3. Fetch the repo's current labels once: `gh label list --json name,color,description --limit 500`.
+4. For each preset label, match by exact name against that list and sort it into one of three buckets:
+   - **Create** — no repo label has this name.
+   - **Reconcile** — a repo label has this name but its color or description differs from the preset. Compare color case-insensitively and ignore a leading `#`; compare description as exact text.
+   - **Skip** — a repo label has this name and both fields already match.
+5. Assemble the exact `gh` command for each create and reconcile. Quote every name:
+   - Create: `gh label create "feature" --color 0e8a16 --description "Brand-new capability"`
+   - Reconcile: `gh label edit "priority: high" --color b60205 --description "High priority"`
+
+## Confirm, then run
+
+6. Show the plan before running anything: the create list, the reconcile list with each label's current values next to the preset values, and the skip count. Print the exact commands from step 5.
+7. Ask once for approval.
+8. On approval, run the commands in order. If a command fails, stop and report which label failed and why; do not roll back labels already changed.
+9. Report the result: how many labels were created, reconciled, and skipped.

--- a/.claude/skills/label-setup/labels.yml
+++ b/.claude/skills/label-setup/labels.yml
@@ -1,0 +1,65 @@
+# Preset label vocabulary for label-setup.
+# label-setup creates and reconciles these labels in a repo; the pr-draft and
+# github-issue-creator skills draw their `labels` suggestions only from this set.
+# One block per label. Colors are quoted six-digit hex, no leading '#'.
+# Edit this file to change the vocabulary; label-setup never writes to it.
+
+- name: bug
+  color: "d73a4a"
+  description: Something isn't working
+
+- name: documentation
+  color: "0075ca"
+  description: Improvements or additions to documentation
+
+- name: feature
+  color: "0e8a16"
+  description: Brand-new capability
+
+- name: enhancement
+  color: "a2eeef"
+  description: Improvement to existing functionality
+
+- name: refactor
+  color: "fbca04"
+  description: Code change, no behavior change
+
+- name: maintenance
+  color: "ededed"
+  description: Upkeep / tooling, no product change
+
+- name: test
+  color: "c5def5"
+  description: Tests
+
+- name: style
+  color: "c2e0c6"
+  description: Formatting, no logic change
+
+- name: security
+  color: "b60205"
+  description: Security-relevant
+
+- name: dependencies
+  color: "0366d6"
+  description: Dependency updates
+
+- name: planning
+  color: "d4c5f9"
+  description: Planning / design work
+
+- name: on-hold
+  color: "ededed"
+  description: Paused
+
+- name: "priority: high"
+  color: "b60205"
+  description: High priority
+
+- name: "priority: medium"
+  color: "fbca04"
+  description: Medium priority
+
+- name: "priority: low"
+  color: "0e8a16"
+  description: Low priority

--- a/.claude/skills/plan-impl/SKILL.md
+++ b/.claude/skills/plan-impl/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: plan-impl
+description: Use this skill whenever the user wants a rough implementation plan — the "how", e.g. breaking a feature into build steps — from an existing product plan, or hands off from `plan-product`. Drafts a doc only; deep verification is the separate `plan-verify` skill.
+---
+
+# Plan Impl
+
+Turn a mature product doc into a rough implementation plan — structure and
+high-level steps. Middle skill in the chain: `plan-product` → **`plan-impl`** →
+`plan-verify`.
+
+## Input, output, and the handoff gate
+
+- Read `docs/plans/<slug>/product.md`. If it is missing, stop and tell the user
+  to run `plan-product` first.
+- **Gate:** every entry in `product.md` must be at `🤖 ai-audited(...)` or above.
+  Read this from the `## Maturity` header — if `lowest:` is `🌱 idea`, stop and
+  tell the user to run an audit pass in `plan-product`. Do not rescan every entry
+  to decide, and do not audit `product.md` yourself here.
+- Write to `docs/plans/<slug>/impl.md` — always this path. Regenerating it
+  overwrites freely. Docs only: never change code, run git, or make a network
+  call.
+
+## Two marks per step, kept separate
+
+Every step carries a maturity mark **and** a verification mark, stacked on one
+line: `🤖 ai-audited(opus-4.8) · ❔ unverified (net-new)`.
+
+Maturity — same axis and same rules as `plan-product`:
+
+```
+🌱 idea   🤖 ai-audited(<model>)   👤 human-ok   ✅ settled
+```
+
+Advance a step to `🤖 ai-audited(<model>)` on your own. Stamp `👤 human-ok` or
+`✅ settled` only when the user explicitly instructs you to set that mark on a
+named step: ask, wait for the instruction, then stamp — one step per instruction.
+Never stamp either mark on your own initiative, and never reuse one step's
+instruction for another.
+
+Verification — this skill leaves almost everything unverified:
+
+```
+❔ unverified (not checked)   step names existing code/tools but nothing was opened
+❔ unverified (net-new)        step builds new code, so there is legitimately nothing to link yet
+```
+
+Do **not** mark any step `🔗 verified` here — attaching real proof is
+`plan-verify`'s job. Use `(net-new)` only for genuinely new code; when a step
+leans on something that should already exist but you have not opened it, use
+`(not checked)` so `plan-verify` knows to look.
+
+## File format — follow this exactly
+
+```markdown
+# Implementation plan: <slug>
+
+## Maturity
+lowest: 🌱 idea
+🌱 idea 4 · 🤖 ai-audited 2 · 👤 human-ok 0 · ✅ settled 0
+
+## Overview
+🤖 ai-audited(opus-4.8) · ❔ unverified (not checked)
+
+<2–4 sentences: the shape of the build and the main moving parts.>
+
+## Risks & unknowns
+🌱 idea · ❔ unverified (not checked)
+
+- <feasibility risk, dependency, or thing that could force a redesign.>
+
+## Steps
+
+### Step 1: <short imperative title>
+🌱 idea · ❔ unverified (net-new)
+
+<what to build and roughly where. Name files/modules when known — they get
+verified later, not now.>
+
+### Step 2: <...>
+🤖 ai-audited(opus-4.8) · ❔ unverified (not checked)
+
+<...>
+```
+
+## Rules
+
+- **Stay rough.** High-level steps that expose unknowns and feasibility risks,
+  not line-by-line instructions or code on paper.
+- **`Risks & unknowns` is required** — never omit it. If a step depends on
+  something you are unsure exists or works, say so there and mark the step
+  `(not checked)`.
+- Each step is a coherent unit of work with a clear boundary — not a micro-task,
+  not a mega-task.
+- **Header can't drift.** Update the `## Maturity` header in the same pass as any
+  entry. Counts cover every marked entry (Overview, Risks, and each step).
+- Never assert a file, function, or library API exists as fact. Phrase such
+  steps as intent, and leave them unverified.
+
+## human-writing
+
+Follow the `human-writing` skill for the prose.
+
+## After writing
+
+Do not render the doc in chat. Show the path and offer:
+
+1. **Revise** — reshape steps, rewrite the file, update the header.
+2. **Run `plan-verify`** — once the product doc is settled and stable, to harden
+   this rough plan into a verified one. Remind the user `plan-verify` is
+   command-only and spends the real verification budget.
+3. **Stop** — the doc stays for later.

--- a/.claude/skills/plan-product/SKILL.md
+++ b/.claude/skills/plan-product/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: plan-product
+description: Use this skill whenever the user wants to turn a feature or project idea into a product plan — the "what and why" — before implementation planning, or hands loose talk over to formalize into requirements and goals. Drafts a doc only.
+---
+
+# Plan Product
+
+Turn a raw idea into a product doc pinning down the "what and why". First skill
+in the chain: `plan-product` → `plan-impl` → `plan-verify`.
+
+## Output
+
+Write to `docs/plans/<slug>/product.md` — always this path. Docs only: never
+change code, run git, or make a network call.
+
+### Choosing the slug
+
+Derive a kebab-case `<slug>` from the idea (e.g. `bulk-export`). Propose it and
+ask the user to accept or rename it **before** creating the directory.
+
+## Two things this skill does
+
+1. **Draft** — build `product.md` from the idea, one marked entry per field.
+2. **Audit** — the only way entries clear the `plan-impl` gate. Defined under
+   `## The maturity mark`.
+
+## The maturity mark
+
+Every entry carries exactly one maturity mark:
+
+```
+🌱 idea               raw, as the user dictated it
+🤖 ai-audited(<model>) Claude reviewed and refined it; stamps the model id
+👤 human-ok           the user reviewed it
+✅ settled            the user locked it
+```
+
+- Fresh dictation is `🌱 idea`.
+- Advance an entry to `🤖 ai-audited(<model>)` on your own. Stamp `👤 human-ok`
+  or `✅ settled` only when the user explicitly instructs you to set that mark on
+  a named entry: ask, wait for the instruction, then stamp — one entry per
+  instruction. Never stamp either mark on your own initiative, and never reuse
+  one entry's instruction for another.
+- Stamp the running model's short id per entry, e.g. `🤖 ai-audited(opus-4.8)`.
+
+An audit pass on an entry means: read it, tighten the wording, flag
+contradictions, gaps, and unknowns, then stamp `🤖 ai-audited(<model>)` with a
+one-line note on what changed or what remains open. Never silently promote an
+entry you did not actually audit.
+
+## File format — follow this exactly
+
+`product.md` opens with a maturity summary header, then one section per field.
+
+```markdown
+# Product plan: <slug>
+
+## Maturity
+lowest: 🌱 idea
+🌱 idea 6 · 🤖 ai-audited 3 · 👤 human-ok 0 · ✅ settled 0
+
+## about
+🌱 idea
+
+<one or two sentences: what this is.>
+
+## problem / motivation
+🤖 ai-audited(opus-4.8) — tightened; still no numbers on how often this hurts
+
+<why it's worth building.>
+
+## goal
+🌱 idea
+
+<the outcome, not the mechanism.>
+
+## audience
+🌱 idea
+
+<who uses it.>
+
+## requirements
+🌱 idea
+
+- When <trigger>, the system shall <response>.   (EARS phrasing)
+- ...
+
+## stack
+🌱 idea
+
+<languages, frameworks, services. Leave empty if undecided.>
+
+## target device / platform
+🌱 idea
+
+<web / mobile / CLI / etc.>
+
+## constraints
+🌱 idea
+
+<hard limits: deadlines, budgets, must-use tech, compliance.>
+
+## non-goals
+🌱 idea
+
+<what this explicitly will not do.>
+
+## open questions
+🌱 idea
+
+<unresolved decisions blocking or shaping the work.>
+```
+
+## Rules
+
+- **Fixed core, optional extras.** The fields above are always present, left
+  empty (not deleted) when they don't apply. A project may append its own extra
+  fields after `open questions`.
+- **`non-goals` and `open questions`** — never leave them blank by default;
+  press for at least one entry each.
+- **Requirements use EARS phrasing** — "When \<trigger>, the system shall
+  \<response>".
+- **Header can't drift.** Whatever writes or updates an entry updates the header
+  in the same pass. `lowest:` is the lowest mark present; the counts sum to the
+  number of entries.
+- Never invent facts to fill a field. An unknown belongs in `open questions`, not
+  a confident-looking guess.
+
+## human-writing
+
+Follow the `human-writing` skill for the prose in every field.
+
+## After writing
+
+Do not render the doc in chat — the user reviews the file in their editor. Show
+the path and offer:
+
+1. **Audit** — run an audit pass to clear entries toward the `plan-impl` gate.
+2. **Revise a field** — reword or re-scope, rewrite the file, update the header.
+3. **Hand off to `plan-impl`** — only once every entry is `🤖 ai-audited` or
+   above (`plan-impl` enforces this from the header).
+4. **Stop** — the doc stays for later.

--- a/.claude/skills/plan-verify/SKILL.md
+++ b/.claude/skills/plan-verify/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: plan-verify
+description: >
+  Harden a rough implementation plan into a verified one — expand each step and
+  attach real proof, promoting confirmed steps to `🔗 verified`. Command-only,
+  run once the product doc is settled and stable: it spends the real
+  verification budget. Drafts a doc only.
+disable-model-invocation: true
+---
+
+# Plan Verify
+
+Verify the rough `impl.md` from `plan-impl` step by step against source code and
+current external documentation, attaching proof to every claim. Last skill in the
+chain: `plan-product` → `plan-impl` → **`plan-verify`**.
+
+## Input and output
+
+- Read `docs/plans/<slug>/impl.md`. If it is missing, stop and tell the user to
+  run `plan-impl` first.
+- The **only** write is back to that same `impl.md`. Read source files and
+  external docs freely to check claims, but never change code, run git, or post
+  to the network yourself. (External research goes through `dev-research`, below.)
+
+## The verification mark
+
+Every step ends at one of:
+
+```
+🔗 verified → src: path/to/file.ts:42          internal: the code exists / behaves as claimed
+🔗 verified → doc: <url> §exact-section         external: the tool/approach is current and standard
+❔ unverified (not checked)                      could not confirm this pass
+❔ unverified (net-new)                          new code, so there is legitimately nothing to link
+```
+
+**No step is marked `🔗 verified` without proof you actually saw this session.**
+
+- **Internal claims** — open the file and cite `file:line` you read. A step that
+  says "add a handler in `FooService`" is verified only after you open the file
+  and confirm `FooService` exists at that line. If it does not exist and the step
+  is building it, that is `❔ unverified (net-new)` — expected, not a failure.
+- **External claims** — a library API, a "standard" approach, a tool that may
+  have changed since the model's training cutoff. Verify these by invoking the
+  `dev-research` skill, which checks against current official docs before
+  asserting. Cite the exact doc page and section it returns. Do not verify an
+  external claim from memory — the cutoff makes that a real hallucination risk.
+
+Leave a step `❔ unverified (not checked)` when you genuinely could not confirm
+it this pass (docs unreachable, ambiguous, out of scope). Never downgrade an
+honest unknown into a fake `🔗 verified`.
+
+## Maturity is a separate axis
+
+The maturity mark (`🌱`/`🤖`/`👤`/`✅`) is independent of verification. Advance a
+step to `🤖 ai-audited(<model>)` on your own. Stamp `👤 human-ok` or `✅ settled`
+only when the user explicitly instructs you to set that mark on a named step:
+ask, wait for the instruction, then stamp — one step per instruction. Never stamp
+either mark on your own initiative, and never reuse one step's instruction for
+another. A step can be `🔗 verified` against source while still `🤖 ai-audited` on
+maturity; that is a valid, expected combination.
+
+## Workflow
+
+1. Read `impl.md`. Work step by step, expanding each rough step into concrete
+   detail as you go.
+2. For each claim in a step, decide internal or external, then verify:
+   - Internal → open the file, confirm, cite `src: file:line`.
+   - External → invoke `dev-research`, cite `doc: <url> §section` it returns.
+   - New code with nothing to check → `❔ unverified (net-new)`.
+   - Couldn't confirm → `❔ unverified (not checked)`, and say why in the step.
+3. Stack both marks on the step's mark line, e.g.
+   `🤖 ai-audited(opus-4.8) · 🔗 verified → src: backend/export.ts:42`.
+4. Update the `## Maturity` header in the same pass so it can't drift.
+
+## human-writing
+
+Follow the `human-writing` skill for any expanded prose.
+
+## After writing
+
+Do not render the doc in chat. Show the path and report a one-line tally: how
+many steps are now `🔗 verified` (src vs doc), how many `net-new`, and how many
+still `not checked` and why. Flag anything the verification pass proved wrong in
+the product plan so the user can revisit it.

--- a/.claude/skills/pr-draft/SKILL.md
+++ b/.claude/skills/pr-draft/SKILL.md
@@ -1,30 +1,36 @@
 ---
 name: pr-draft
-description: Use this skill whenever the user wants a pull request title and description drafted from the current branch — including when they ask to "create/open/make a PR" (drafting the text is this skill's step) or want text to paste into GitHub's PR form. Drafts only: never push, never create a PR, never use `gh` or the GitHub API.
+description: Use this skill whenever the user wants a pull request title and description drafted from the current branch — including when they ask to "create/open/make a PR" (drafting the text is this skill's step). Drafts only: never push, create a PR, or use `gh` or the GitHub API.
 ---
 
 # PR Draft
 
-Produce a paste-ready PR title and body from local git history; the user pastes it into the GitHub web UI.
+Produce a PR title and body from local git history and write them to a draft file the user reviews before publishing.
 
 ## Hard limits
 
-- Read-only local git only. Never `git push`, never `gh`, never any network call — including `git fetch` and `git pull`. Diff against the local base ref even if it may be stale.
+- Read-only git, never `gh`. Allowed network calls: `git ls-remote` and `git fetch origin main` in that exact form — never push, pull, or any other fetch.
 - Draft only: never create, update, or comment on a pull request.
 
 ## Gather input
 
-1. Detect the base branch: `git symbolic-ref refs/remotes/origin/HEAD --short`, stripped of the remote prefix. If that fails, use `main`, or `master` when there is no `main`.
-2. Collect the branch's work: `git log <base>..HEAD` and `git diff <base>...HEAD --stat`. If the log is empty (on the base branch, or no commits yet), stop and tell the user there is nothing to draft — never invent one.
-3. Read the full diff of any file whose purpose is unclear from the stat and commit messages. Never paste raw diffs into the draft.
-4. Run `git status`; if anything is uncommitted, note in chat that it is not part of the draft.
-5. If `.github/PULL_REQUEST_TEMPLATE.md` exists, fill its structure instead of the default one below.
+1. Detect the base branch: `git rev-parse --abbrev-ref refs/remotes/origin/HEAD`, stripped of the `origin/` prefix. If that fails, use `main`, or `master` when there is no `main`.
+2. Confirm the base is fresh:
+   - Base is `main`: run `git fetch origin main` — exact form only — then diff against the refreshed `origin/main`.
+   - Any other base, or the fetch failed: compare `git ls-remote origin <base>` against `git rev-parse origin/<base>`. On matching SHAs, continue with the local ref.
+   - On SHA mismatch or `ls-remote` failure: stop, report the failing step, and produce no draft.
+3. Collect the branch's work: `git log <base>..HEAD` and `git diff <base>...HEAD --stat`. If the log is empty (on the base branch, or no commits yet), stop and tell the user there is nothing to draft — never invent one.
+4. Read the full diff of any file whose purpose is unclear from the stat and commit messages. Never paste raw diffs into the draft.
+5. Run `git status`; if anything is uncommitted, note in chat that it is not part of the draft.
+6. If `.github/PULL_REQUEST_TEMPLATE.md` exists, fill its structure instead of the default one below.
 
 ## Write the draft
 
 Follow the `human-writing` skill for the body text.
 
 Title: under 70 characters, imperative mood. Use a `feat:`, `fix:`, `refactor:`, `docs:`, `chore:` prefix when the branch's commits already use that convention.
+
+Labels: draw only from the preset `.claude/skills/label-setup/labels.yml` — never a label outside it. Keep the set small: usually one type label (e.g. `feature`, `bug`, `refactor`), optionally paired with one `priority:` label. Don't stack overlapping types. Use an empty list when none apply.
 
 Default body structure (when there is no PR template):
 
@@ -43,9 +49,20 @@ File format:
 ```markdown
 ---
 title: "feat: share validation between create and update endpoints"
+base: main
+labels: [feature, refactor]
 ---
 
 <body, ready to paste into the GitHub PR form>
 ```
 
-After writing the file, show the rendered draft in chat and give the file path.
+`base` is the base branch confirmed in step 2.
+
+## After writing
+
+Do not render the draft in chat — the user reviews the file in their editor. Show the file path and ask them to choose:
+
+1. **Happy, publish** — hand off to the `pr-publish` skill.
+2. **Needs change** — revise the draft, rewrite the file, and ask again.
+3. **Happy, but don't publish now** — stop; the draft file stays for later.
+4. **Something else** — open-ended.

--- a/.claude/skills/pr-publish/SKILL.md
+++ b/.claude/skills/pr-publish/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: pr-publish
+description: >
+  Create or edit a GitHub pull request with `gh` from the reviewed draft at
+  `.github/drafts/pr-draft.md`. Use only when that draft exists and the user
+  asks to publish, open, or push it live — typically handed off from
+  `pr-draft`. Opens the PR in draft state assigned to the user; never merges
+  or pushes commits.
+---
+
+# PR Publish
+
+Publish the PR draft by running the steps below in order.
+
+## Hard limits
+
+- GitHub PR writes only, and only `gh pr create` / `gh pr edit`. Never merge, comment, close, reopen, or mark a PR ready.
+- Never push, pull, commit, or change branches.
+- Never edit the draft or any tracked file. The only file you may write is the temporary body file in step 9.
+- Read-only git and read-only `gh` for every precondition.
+
+## Read the draft
+
+1. Read `.github/drafts/pr-draft.md`. If it is missing, stop and tell the user to run `pr-draft` first.
+2. Parse the front-matter: `title`, `base`, `labels`. Everything after the closing `---` is the body. Use these values verbatim — never rewrite them.
+3. Record the head branch: `git rev-parse --abbrev-ref HEAD`. If it equals `base`, stop — a branch cannot open a PR against itself.
+
+## Preconditions
+
+Any failure here stops the skill with no PR written.
+
+4. **Branch is on the remote.** `git ls-remote --heads origin <branch>` must return a line. If it is empty, stop and tell the user to push the branch first — never push it yourself.
+5. **Nothing local is unpushed.** Take the remote SHA from step 4's output and confirm the remote branch contains local `HEAD`: `git merge-base --is-ancestor HEAD <remote-sha>`. Exit 0 means the remote holds everything local. Any other result (including an unknown object) means local is ahead or unconfirmed — stop and tell the user to push first.
+
+## Create vs edit
+
+6. Look up the open PR for this pair: `gh pr list --head <branch> --base <base> --state open --json number`. GitHub allows at most one.
+   - A result — edit that PR number with `gh pr edit`.
+   - Empty — create with `gh pr create`.
+
+## Labels
+
+7. Fetch the repo's labels once: `gh label list --json name --limit 500`.
+8. Every label the draft names must already exist. If any is missing, stop, list the missing names, and tell the user to run `/label-setup` — never create labels.
+
+## Assemble, confirm, run
+
+9. Write the body to a temporary file outside the repo with `mktemp`. Pass it as `--body-file`.
+10. Assemble the exact command. Apply the constants the draft does not carry: `--draft` and `--assignee @me` on create.
+    - Create:
+      ```
+      gh pr create --title "<title>" --body-file <tmpfile> \
+        --base <base> --head <branch> --draft --assignee @me \
+        --label "<label>"   # repeat --label per label
+      ```
+    - Edit (`--draft` and assignee are not re-applied; add labels without removing any):
+      ```
+      gh pr edit <number> --title "<title>" --body-file <tmpfile> \
+        --base <base> --add-label "<label>"   # repeat --add-label per label
+      ```
+11. Show the assembled command(s) in full and ask once for approval. Run nothing until the user approves.
+12. On approval, run the command, then delete the temporary body file. Report the PR URL `gh` prints, and note it opened in draft state — the user marks it ready for review on GitHub.

--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -5,6 +5,11 @@
       "resolved": "ghcr.io/anthropics/devcontainer-features/claude-code@sha256:cfc2e7d3e9fd3b9b01f8d5cb158508a884c8c0ede2e23ed10f32dea5d4ffe69a",
       "integrity": "sha256:cfc2e7d3e9fd3b9b01f8d5cb158508a884c8c0ede2e23ed10f32dea5d4ffe69a"
     },
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "version": "1.1.0",
+      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
+      "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
+    },
     "ghcr.io/devcontainers/features/node:1": {
       "version": "1.7.1",
       "resolved": "ghcr.io/devcontainers/features/node@sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,7 +9,9 @@
 		// Node.js for frontend
 		"ghcr.io/devcontainers/features/node:1": {},
 		// Claude Code
-		"ghcr.io/anthropics/devcontainer-features/claude-code:1.0": {}
+		"ghcr.io/anthropics/devcontainer-features/claude-code:1.0": {},
+		// GitHub CLI
+		"ghcr.io/devcontainers/features/github-cli:1": {}
 	},
 
 	// Features to add to the dev container. More info: https://containers.dev/features.

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ docker-compose.override.yml
 
 # Development notes and sample files
 notes/
+memory/
 SampleFile/
 
 # Local configuration files from Backend

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,7 @@ The dev environment runs in a Dev Container (`.devcontainer/`) with the PostgreS
 - `docs/progress.md` — read at session start; update after each major feature completes.
 - `docs/plans/` — per-feature plan/decision files; read only the relevant file when working on a feature.
 - `docs/company-verification-api-reference.md` — contract for the external company verification API.
+- `memory/` — Claude session memory (gitignored). Read/write here, not the default hidden auto-memory location. Promote durable decisions to CLAUDE.md or a skill only with user review.
 
 ## Commands
 

--- a/JobTrackerApi/Data/JobTrackerContext.cs
+++ b/JobTrackerApi/Data/JobTrackerContext.cs
@@ -47,6 +47,10 @@ public class JobTrackerContext : IdentityDbContext<ApplicationUser>
         modelBuilder.Entity<UserProfile>()
             .PrimitiveCollection(p => p.ContractTypes)
             .HasColumnType("jsonb");
+        modelBuilder.Entity<UserProfile>()
+            .OwnsOne(p => p.SalaryExpectation, se => se.ToJson());
+        modelBuilder.Entity<UserProfile>()
+            .OwnsMany(p => p.PreferredLocations, pl => pl.ToJson());
     }
 
     public DbSet<Job> Jobs { get; set; } = null!;

--- a/JobTrackerApi/Data/JobTrackerContext.cs
+++ b/JobTrackerApi/Data/JobTrackerContext.cs
@@ -40,6 +40,13 @@ public class JobTrackerContext : IdentityDbContext<ApplicationUser>
             .OwnsMany(p => p.WorkHistory, wh => wh.ToJson());
         modelBuilder.Entity<UserProfile>()
             .OwnsMany(p => p.Education, e => e.ToJson());
+        // PrimitiveCollection is the EF Core 8 API for List<enum/scalar>; OwnsMany only works for entity types
+        modelBuilder.Entity<UserProfile>()
+            .PrimitiveCollection(p => p.WorkModes)
+            .HasColumnType("jsonb");
+        modelBuilder.Entity<UserProfile>()
+            .PrimitiveCollection(p => p.ContractTypes)
+            .HasColumnType("jsonb");
     }
 
     public DbSet<Job> Jobs { get; set; } = null!;

--- a/JobTrackerApi/Migrations/20260712024749_ProfileConditions.Designer.cs
+++ b/JobTrackerApi/Migrations/20260712024749_ProfileConditions.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using JobTrackerApi.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace JobTrackerApi.Migrations
 {
     [DbContext(typeof(JobTrackerContext))]
-    partial class JobTrackerContextModelSnapshot : ModelSnapshot
+    [Migration("20260712024749_ProfileConditions")]
+    partial class ProfileConditions
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/JobTrackerApi/Migrations/20260712024749_ProfileConditions.cs
+++ b/JobTrackerApi/Migrations/20260712024749_ProfileConditions.cs
@@ -1,0 +1,70 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace JobTrackerApi.Migrations
+{
+    /// <inheritdoc />
+    public partial class ProfileConditions : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "AdditionalConditions",
+                table: "UserProfiles",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ContractTypes",
+                table: "UserProfiles",
+                type: "jsonb",
+                nullable: false,
+                defaultValue: "[]");
+
+            migrationBuilder.AddColumn<string>(
+                name: "PreferredLocations",
+                table: "UserProfiles",
+                type: "jsonb",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "SalaryExpectation",
+                table: "UserProfiles",
+                type: "jsonb",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "WorkModes",
+                table: "UserProfiles",
+                type: "jsonb",
+                nullable: false,
+                defaultValue: "[]");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "AdditionalConditions",
+                table: "UserProfiles");
+
+            migrationBuilder.DropColumn(
+                name: "ContractTypes",
+                table: "UserProfiles");
+
+            migrationBuilder.DropColumn(
+                name: "PreferredLocations",
+                table: "UserProfiles");
+
+            migrationBuilder.DropColumn(
+                name: "SalaryExpectation",
+                table: "UserProfiles");
+
+            migrationBuilder.DropColumn(
+                name: "WorkModes",
+                table: "UserProfiles");
+        }
+    }
+}

--- a/JobTrackerApi/Models/AnalysisModels.cs
+++ b/JobTrackerApi/Models/AnalysisModels.cs
@@ -1,0 +1,32 @@
+using System.Text.Json.Serialization;
+
+namespace JobTrackerApi.Models;
+
+public record AlignmentResult(
+    [property: JsonPropertyName("score")]     int    Score,
+    [property: JsonPropertyName("reasoning")] string Reasoning
+);
+
+public record SkillsResult(
+    [property: JsonPropertyName("skills")] string[] Skills
+);
+
+public record GapItem(
+    [property: JsonPropertyName("gap")]    string Gap,
+    [property: JsonPropertyName("advice")] string Advice
+);
+
+public record GapsResult(
+    [property: JsonPropertyName("gaps")] GapItem[] Gaps
+);
+
+/// <summary>Shared shape for Questions-to-ask and Interview-questions endpoints.</summary>
+public record QuestionsResult(
+    [property: JsonPropertyName("questions")] string[] Questions
+);
+
+/// <summary>Thrown when Claude returns an unparseable or structurally invalid response.</summary>
+public class AnalysisFormatException : Exception
+{
+    public AnalysisFormatException(string message, Exception? inner = null) : base(message, inner) { }
+}

--- a/JobTrackerApi/Models/Enums/ContractType.cs
+++ b/JobTrackerApi/Models/Enums/ContractType.cs
@@ -1,0 +1,12 @@
+namespace JobTrackerApi.Models;
+
+/// <summary>A type of employment contract a candidate will accept.</summary>
+public enum ContractType
+{
+    FullTimePermanent,
+    FullTimeContract,
+    PartTime,
+    Casual,
+    Internship,
+    Temporary
+}

--- a/JobTrackerApi/Models/Enums/SalaryPeriod.cs
+++ b/JobTrackerApi/Models/Enums/SalaryPeriod.cs
@@ -1,0 +1,9 @@
+namespace JobTrackerApi.Models;
+
+/// <summary>The period a salary figure is quoted over.</summary>
+public enum SalaryPeriod
+{
+    Annual,
+    Monthly,
+    Hourly
+}

--- a/JobTrackerApi/Models/PreferredLocationEntry.cs
+++ b/JobTrackerApi/Models/PreferredLocationEntry.cs
@@ -1,0 +1,16 @@
+namespace JobTrackerApi.Models;
+using System.ComponentModel.DataAnnotations;
+
+/// <summary>A place the candidate wants to work: a country, optionally narrowed to specific areas.</summary>
+public class PreferredLocationEntry
+{
+    [Required]
+    [MaxLength(2)]
+    // ISO 3166-1 alpha-2 code, e.g. "NZ", "AU"
+    [RegularExpression(@"^[A-Z]{2}$", ErrorMessage = "Country must be a valid ISO 3166-1 alpha-2 code (e.g. NZ, AU).")]
+    public string Country { get; set; } = null!;
+
+    // Empty = anywhere in the country; otherwise specific cities/regions.
+    [MaxLength(ValidationConstants.MaxProfileLocationAreasCount)]
+    public List<string> Areas { get; set; } = [];
+}

--- a/JobTrackerApi/Models/ProfileDTO.cs
+++ b/JobTrackerApi/Models/ProfileDTO.cs
@@ -62,6 +62,16 @@ public class ProfileDTO : IValidatableObject
             yield return new ValidationResult(
                 $"Each language must be {ValidationConstants.MaxProfileLanguageItemLength} characters or fewer.",
                 [nameof(Languages)]);
+
+        if (PreferredLocations?.Any(l => l.Areas.Any(a => a?.Length > ValidationConstants.MaxProfileLocationAreaItemLength)) == true)
+            yield return new ValidationResult(
+                $"Each location area must be {ValidationConstants.MaxProfileLocationAreaItemLength} characters or fewer.",
+                [nameof(PreferredLocations)]);
+
+        if (AdditionalConditions != null && System.Text.RegularExpressions.Regex.IsMatch(AdditionalConditions, @"<[a-zA-Z/]"))
+            yield return new ValidationResult(
+                "Additional conditions must not contain HTML.",
+                [nameof(AdditionalConditions)]);
     }
 
     /// <summary>Creates a new UserProfile entity from this DTO (used by PUT).</summary>

--- a/JobTrackerApi/Models/ProfileDTO.cs
+++ b/JobTrackerApi/Models/ProfileDTO.cs
@@ -8,6 +8,20 @@ public class ProfileDTO : IValidatableObject
     [MaxLength(ValidationConstants.MaxProfileTargetRolesCount)]
     public List<string>? TargetRoles { get; set; }
 
+    [MaxLength(ValidationConstants.MaxProfileWorkModesCount)]
+    public List<WorkMode>? WorkModes { get; set; }
+
+    [MaxLength(ValidationConstants.MaxProfileContractTypesCount)]
+    public List<ContractType>? ContractTypes { get; set; }
+
+    public SalaryExpectation? SalaryExpectation { get; set; }
+
+    [MaxLength(ValidationConstants.MaxProfileLocationsCount)]
+    public List<PreferredLocationEntry>? PreferredLocations { get; set; }
+
+    [MaxLength(ValidationConstants.MaxProfileAdditionalConditionsLength)]
+    public string? AdditionalConditions { get; set; }
+
     [MaxLength(ValidationConstants.MaxProfileSkillsCount)]
     public List<string>? Skills { get; set; }
 

--- a/JobTrackerApi/Models/ProfileDTO.cs
+++ b/JobTrackerApi/Models/ProfileDTO.cs
@@ -96,6 +96,11 @@ public class ProfileDTO : IValidatableObject
     public void ApplyTo(UserProfile profile)
     {
         if (TargetRoles != null) profile.TargetRoles = TargetRoles;
+        if (WorkModes != null) profile.WorkModes = WorkModes;
+        if (ContractTypes != null) profile.ContractTypes = ContractTypes;
+        if (SalaryExpectation != null) profile.SalaryExpectation = SalaryExpectation;
+        if (PreferredLocations != null) profile.PreferredLocations = PreferredLocations;
+        if (AdditionalConditions != null) profile.AdditionalConditions = AdditionalConditions;
         if (Skills != null) profile.Skills = Skills;
         if (Certifications != null) profile.Certifications = Certifications;
         if (Languages != null) profile.Languages = Languages;

--- a/JobTrackerApi/Models/ProfileDTO.cs
+++ b/JobTrackerApi/Models/ProfileDTO.cs
@@ -79,6 +79,11 @@ public class ProfileDTO : IValidatableObject
     {
         UserId = userId,
         TargetRoles = TargetRoles ?? [],
+        WorkModes = WorkModes ?? [],
+        ContractTypes = ContractTypes ?? [],
+        SalaryExpectation = SalaryExpectation,   // nullable on entity; null = not set
+        PreferredLocations = PreferredLocations ?? [],
+        AdditionalConditions = AdditionalConditions, // nullable on entity; null = not set
         Skills = Skills ?? [],
         Certifications = Certifications ?? [],
         Languages = Languages ?? [],

--- a/JobTrackerApi/Models/ProfileResponseDto.cs
+++ b/JobTrackerApi/Models/ProfileResponseDto.cs
@@ -3,7 +3,15 @@ namespace JobTrackerApi.Models;
 /// <summary>Response shape for GET /api/account/profile.</summary>
 public class ProfileResponseDto
 {
+    // What I'm looking for
     public List<string> TargetRoles { get; set; } = [];
+    public List<WorkMode> WorkModes { get; set; } = [];
+    public List<ContractType> ContractTypes { get; set; } = [];
+    public SalaryExpectation? SalaryExpectation { get; set; }
+    public List<PreferredLocationEntry> PreferredLocations { get; set; } = [];
+    public string? AdditionalConditions { get; set; }
+
+    // Background
     public List<string> Skills { get; set; } = [];
     public List<string> Certifications { get; set; } = [];
     public List<string> Languages { get; set; } = [];

--- a/JobTrackerApi/Models/SalaryExpectation.cs
+++ b/JobTrackerApi/Models/SalaryExpectation.cs
@@ -1,0 +1,21 @@
+namespace JobTrackerApi.Models;
+using System.ComponentModel.DataAnnotations;
+
+/// <summary>A candidate's minimum acceptable salary, with its currency and period.</summary>
+public class SalaryExpectation
+{
+    [Required]
+    [Range(0, ValidationConstants.MaxSalaryAmount)]
+    public int? MinAmount { get; set; }
+
+    [Required]
+    [MaxLength(3)]
+    // ISO 4217 alpha-3 code, e.g. "NZD", "JPY"
+    [RegularExpression(@"^[A-Z]{3}$", ErrorMessage = "Currency must be a valid ISO 4217 alpha-3 code (e.g. NZD, JPY).")]
+    public string Currency { get; set; } = null!;
+
+    // Nullable so [Required] actually rejects an omitted value
+    // a non-nullable enum would silently default to Annual
+    [Required]
+    public SalaryPeriod? Period { get; set; }
+}

--- a/JobTrackerApi/Models/UserProfile.cs
+++ b/JobTrackerApi/Models/UserProfile.cs
@@ -18,6 +18,18 @@ public class UserProfile
     public List<WorkHistoryEntry> WorkHistory { get; set; } = [];
     public List<EducationEntry> Education { get; set; } = [];
 
+    // JSONB via PrimitiveCollection — see JobTrackerContext
+    public List<WorkMode> WorkModes { get; set; } = [];
+    public List<ContractType> ContractTypes { get; set; } = [];
+
+    // JSONB via OwnsOne — see JobTrackerContext
+    public SalaryExpectation? SalaryExpectation { get; set; }
+
+    // JSONB via OwnsMany — see JobTrackerContext
+    public List<PreferredLocationEntry> PreferredLocations { get; set; } = [];
+
+    public string? AdditionalConditions { get; set; }
+
     public ProfileResponseDto ToResponseDto() => new()
     {
         TargetRoles = TargetRoles,

--- a/JobTrackerApi/Models/UserProfile.cs
+++ b/JobTrackerApi/Models/UserProfile.cs
@@ -33,6 +33,11 @@ public class UserProfile
     public ProfileResponseDto ToResponseDto() => new()
     {
         TargetRoles = TargetRoles,
+        WorkModes = WorkModes,
+        ContractTypes = ContractTypes,
+        SalaryExpectation = SalaryExpectation,
+        PreferredLocations = PreferredLocations,
+        AdditionalConditions = AdditionalConditions,
         Skills = Skills,
         Certifications = Certifications,
         Languages = Languages,

--- a/JobTrackerApi/Models/ValidationConstants.cs
+++ b/JobTrackerApi/Models/ValidationConstants.cs
@@ -51,4 +51,17 @@ public static class ValidationConstants
     public const int MaxProfileWorkHistoryDescriptionLength = 2000;
     public const int MaxProfileEducationInstitutionLength = 100;
     public const int MaxProfileEducationDegreeLength = 100;
+
+    // Profile conditions — array count limits
+    public const int MaxProfileWorkModesCount     = 3;
+    public const int MaxProfileContractTypesCount = 6;
+    public const int MaxProfileLocationsCount     = 10;
+    public const int MaxProfileLocationAreasCount = 10;
+
+    // Profile conditions — string length limits
+    public const int MaxProfileLocationAreaItemLength    = 100;
+    public const int MaxProfileAdditionalConditionsLength = 500;
+
+    // Profile conditions — salary expectation ceiling (bounds abuse; covers any currency/period)
+    public const int MaxSalaryAmount = 100_000_000;
 }

--- a/JobTrackerApi/Models/WorkingRightEntry.cs
+++ b/JobTrackerApi/Models/WorkingRightEntry.cs
@@ -10,6 +10,7 @@ public class WorkingRightEntry
     [RegularExpression(@"^[A-Z]{2}$", ErrorMessage = "Country must be a valid ISO 3166-1 alpha-2 code (e.g. NZ, AU).")]
     public string Country { get; set; } = null!;
 
+    // Nullable so [Required] rejects an omitted status
     [Required]
-    public WorkingRight Status { get; set; }
+    public WorkingRight? Status { get; set; }
 }

--- a/JobTrackerApi/Services/ClaudeAnalysisConfig.cs
+++ b/JobTrackerApi/Services/ClaudeAnalysisConfig.cs
@@ -1,0 +1,69 @@
+namespace JobTrackerApi.Services;
+
+/// <summary>Model, token budget, count bounds, and system prompts for the Claude-based job analyser.</summary>
+internal static class ClaudeAnalysisConfig
+{
+    public const string Model     = "claude-haiku-4-5-20251001";
+    public const int    MaxTokens = 512;
+
+    // Count bounds — interpolated into each prompt below so prompt text always matches the consts.
+    public const int MinSkillCount             = 5;
+    public const int MaxSkillCount             = 8;
+    public const int MinGapCount               = 2;
+    public const int MaxGapCount               = 4;
+    public const int MinQuestionToAskCount     = 3;
+    public const int MaxQuestionToAskCount     = 5;
+    public const int MinInterviewQuestionCount = 4;
+    public const int MaxInterviewQuestionCount = 6;
+
+    // TODO: prompts are placeholder quality — polish in a dedicated session before shipping.
+    public static readonly string AlignmentPrompt = """
+        You are a career advisor assessing how well a candidate's profile matches a job.
+        Rate the alignment on a scale of 1–5 (1 = poor fit, 5 = excellent fit) and give a one-sentence reason.
+        Return valid JSON only. No markdown fences, no prose before or after.
+
+        {"score": 4, "reasoning": "Strong frontend skills match the role, though limited backend experience is a gap."}
+
+        score must be an integer 1–5. reasoning must be a single sentence.
+        """;
+
+    public static readonly string SkillsPrompt = $$"""
+        You are a career advisor identifying the most important skills for a specific role.
+        Given the job description and the candidate's profile for context, list the {{MinSkillCount}}–{{MaxSkillCount}} skills most critical for success in this role.
+        Return valid JSON only. No markdown fences, no prose before or after.
+
+        {"skills": ["TypeScript", "React", "Node.js", "REST APIs", "CI/CD", "PostgreSQL"]}
+
+        Return exactly {{MinSkillCount}}–{{MaxSkillCount}} items. Skills should be concise (1–4 words).
+        """;
+
+    public static readonly string GapsPrompt = $$"""
+        You are a career advisor identifying gaps between a candidate's profile and a job.
+        Identify {{MinGapCount}}–{{MaxGapCount}} specific gaps where the candidate falls short, each with brief, practical advice.
+        Return valid JSON only. No markdown fences, no prose before or after.
+
+        {"gaps": [{"gap": "No cloud experience", "advice": "Highlight any personal AWS/Azure projects and your transferable infrastructure knowledge from C#."}]}
+
+        Return exactly {{MinGapCount}}–{{MaxGapCount}} gap objects. gap and advice are required strings.
+        """;
+
+    public static readonly string QuestionsToAskPrompt = $$"""
+        You are a career advisor helping a candidate prepare thoughtful questions for an interview.
+        Given the candidate's profile and the job description, suggest {{MinQuestionToAskCount}}–{{MaxQuestionToAskCount}} questions the candidate should ask the interviewer.
+        Return valid JSON only. No markdown fences, no prose before or after.
+
+        {"questions": ["What does success look like in the first 90 days?", "How is the on-call rotation structured?"]}
+
+        Return exactly {{MinQuestionToAskCount}}–{{MaxQuestionToAskCount}} questions as an array of strings.
+        """;
+
+    public static readonly string InterviewQuestionsPrompt = $$"""
+        You are a career advisor predicting interview questions for a specific role.
+        Given the candidate's profile and the job description, predict {{MinInterviewQuestionCount}}–{{MaxInterviewQuestionCount}} questions the interviewer is likely to ask this candidate.
+        Return valid JSON only. No markdown fences, no prose before or after.
+
+        {"questions": ["Tell me about a time you handled a difficult stakeholder.", "How do you approach performance optimisation?"]}
+
+        Return exactly {{MinInterviewQuestionCount}}–{{MaxInterviewQuestionCount}} questions as an array of strings.
+        """;
+}

--- a/JobTrackerApi/Services/ClaudeAnalysisService.cs
+++ b/JobTrackerApi/Services/ClaudeAnalysisService.cs
@@ -1,0 +1,198 @@
+using System.Globalization;
+using System.Text;
+using System.Text.Json;
+using Anthropic.SDK;
+using Anthropic.SDK.Messaging;
+using JobTrackerApi.Models;
+
+namespace JobTrackerApi.Services;
+
+/// <summary>Production implementation — analyses jobs against a user profile via the Claude API.</summary>
+public class ClaudeAnalysisService : IAnalysisService
+{
+    private readonly AnthropicClient _client;
+    private readonly ILogger<ClaudeAnalysisService> _logger;
+
+    public ClaudeAnalysisService(IConfiguration configuration, ILogger<ClaudeAnalysisService> logger)
+    {
+        var apiKey = configuration["Anthropic:ApiKey"]
+            ?? throw new InvalidOperationException("Anthropic:ApiKey is not configured.");
+
+        // No retry policy — same deliberate choice as ClaudeParsingService.
+        _client = new AnthropicClient(apiKey, new HttpClient());
+        _logger = logger;
+    }
+
+    public async Task<AlignmentResult> AnalyseAlignmentAsync(UserProfile profile, string description, string? role, string? company)
+    {
+        var result = await CallClaudeAsync<AlignmentResult>(
+            ClaudeAnalysisConfig.AlignmentPrompt,
+            FormatUserMessage(profile, description, role, company));
+
+        if (result.Score < 1 || result.Score > 5 || string.IsNullOrWhiteSpace(result.Reasoning))
+            throw new AnalysisFormatException($"Alignment response failed field validation. Score={result.Score}");
+
+        return result;
+    }
+
+    public async Task<SkillsResult> AnalyseSkillsAsync(UserProfile profile, string description, string? role, string? company)
+    {
+        var result = await CallClaudeAsync<SkillsResult>(
+            ClaudeAnalysisConfig.SkillsPrompt,
+            FormatUserMessage(profile, description, role, company));
+
+        if (result.Skills is not { Length: >= 1 })
+            throw new AnalysisFormatException("Skills response is empty or missing.");
+
+        return result;
+    }
+
+    public async Task<GapsResult> AnalyseGapsAsync(UserProfile profile, string description, string? role, string? company)
+    {
+        var result = await CallClaudeAsync<GapsResult>(
+            ClaudeAnalysisConfig.GapsPrompt,
+            FormatUserMessage(profile, description, role, company));
+
+        if (result.Gaps is not { Length: >= 1 })
+            throw new AnalysisFormatException("Gaps response is empty or missing.");
+
+        return result;
+    }
+
+    public async Task<QuestionsResult> AnalyseQuestionsToAskAsync(UserProfile profile, string description, string? role, string? company)
+    {
+        var result = await CallClaudeAsync<QuestionsResult>(
+            ClaudeAnalysisConfig.QuestionsToAskPrompt,
+            FormatUserMessage(profile, description, role, company));
+
+        if (result.Questions is not { Length: >= 1 })
+            throw new AnalysisFormatException("Questions-to-ask response is empty or missing.");
+
+        return result;
+    }
+
+    public async Task<QuestionsResult> AnalyseInterviewQuestionsAsync(UserProfile profile, string description, string? role, string? company)
+    {
+        var result = await CallClaudeAsync<QuestionsResult>(
+            ClaudeAnalysisConfig.InterviewQuestionsPrompt,
+            FormatUserMessage(profile, description, role, company));
+
+        if (result.Questions is not { Length: >= 1 })
+            throw new AnalysisFormatException("Interview questions response is empty or missing.");
+
+        return result;
+    }
+
+    private async Task<T> CallClaudeAsync<T>(string systemPrompt, string userMessage)
+    {
+        string raw;
+        try
+        {
+            var response = await _client.Messages.GetClaudeMessageAsync(new MessageParameters
+            {
+                Model     = ClaudeAnalysisConfig.Model,
+                MaxTokens = ClaudeAnalysisConfig.MaxTokens,
+                System    = [new SystemMessage(systemPrompt)],
+                Messages  = [new Message(RoleType.User, userMessage)]
+            });
+            raw = response.Content.OfType<TextContent>().FirstOrDefault()?.Text ?? string.Empty;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Claude API call failed during analysis.");
+            throw new AnalysisFormatException("Claude API request failed.", ex);
+        }
+
+        var json = ExtractJson(raw);
+        try
+        {
+            return JsonSerializer.Deserialize<T>(json)
+                ?? throw new AnalysisFormatException($"Claude analysis response deserialized to null. Raw: {raw}");
+        }
+        catch (JsonException ex)
+        {
+            _logger.LogWarning(ex, "Failed to deserialize analysis response. Raw: {Raw}", raw);
+            throw new AnalysisFormatException("Claude analysis response could not be parsed.", ex);
+        }
+    }
+
+    // Claude may return prose around the JSON despite instructions — extract the first { } block.
+    // Falls back to "{}" so deserialization always runs; field validation in each public method catches the empty result.
+    private string ExtractJson(string raw)
+    {
+        var trimmed = raw.Trim();
+        var start   = trimmed.IndexOf('{');
+        var end     = trimmed.LastIndexOf('}');
+
+        if (start == -1 || end == -1 || end < start)
+        {
+            _logger.LogWarning("Analysis response contains no JSON object. Raw: {Raw}", raw);
+            return "{}";
+        }
+
+        var json = trimmed[start..(end + 1)];
+
+        if (start > 0 || end < trimmed.Length - 1)
+            _logger.LogWarning("Analysis response contains text outside JSON. Raw: {Raw}", raw);
+
+        return json;
+    }
+
+    private static string FormatUserMessage(UserProfile profile, string description, string? role, string? company)
+    {
+        var sb = new StringBuilder();
+
+        sb.AppendLine("## Candidate Profile");
+        sb.AppendLine($"Target roles: {(profile.TargetRoles.Count > 0 ? string.Join(", ", profile.TargetRoles) : "None listed")}");
+        sb.AppendLine($"Skills: {(profile.Skills.Count > 0 ? string.Join(", ", profile.Skills) : "None listed")}");
+        sb.AppendLine($"Certifications: {(profile.Certifications.Count > 0 ? string.Join(", ", profile.Certifications) : "None listed")}");
+        sb.AppendLine($"Languages: {(profile.Languages.Count > 0 ? string.Join(", ", profile.Languages) : "None listed")}");
+
+        if (profile.WorkingRights.Count > 0)
+            sb.AppendLine($"Working rights: {string.Join(", ", profile.WorkingRights.Select(r => $"{r.Country}: {r.Status}"))}");
+
+        if (profile.WorkHistory.Count > 0)
+        {
+            sb.AppendLine("Work history:");
+            foreach (var w in profile.WorkHistory)
+            {
+                sb.AppendLine($"  - {w.Title} at {w.Company} ({FormatDateRange(w.FromYear, w.FromMonth, w.ToYear, w.ToMonth)})");
+                if (!string.IsNullOrWhiteSpace(w.Description))
+                    sb.AppendLine($"    {w.Description}");
+            }
+        }
+
+        if (profile.Education.Count > 0)
+        {
+            sb.AppendLine("Education:");
+            foreach (var e in profile.Education)
+            {
+                var to = e.To.HasValue ? e.To.Value.ToString() : "present";
+                sb.AppendLine($"  - {e.Degree}, {e.Institution} ({e.From} – {to})");
+            }
+        }
+
+        sb.AppendLine();
+        sb.AppendLine("## Job");
+        if (role    is not null) sb.AppendLine($"Role: {role}");
+        if (company is not null) sb.AppendLine($"Company: {company}");
+        sb.AppendLine();
+        sb.AppendLine("## Job Description");
+        sb.Append(description);
+
+        return sb.ToString();
+    }
+
+    private static string FormatDateRange(int fromYear, int? fromMonth, int? toYear, int? toMonth)
+    {
+        var from = fromMonth.HasValue
+            ? $"{new DateTime(2000, fromMonth.Value, 1).ToString("MMM", CultureInfo.InvariantCulture)} {fromYear}"
+            : $"{fromYear}";
+        var to = toYear.HasValue
+            ? (toMonth.HasValue
+                ? $"{new DateTime(2000, toMonth.Value, 1).ToString("MMM", CultureInfo.InvariantCulture)} {toYear}"
+                : $"{toYear}")
+            : "present";
+        return $"{from} – {to}";
+    }
+}

--- a/JobTrackerApi/Services/IAnalysisService.cs
+++ b/JobTrackerApi/Services/IAnalysisService.cs
@@ -1,0 +1,13 @@
+using JobTrackerApi.Models;
+
+namespace JobTrackerApi.Services;
+
+/// <summary>Abstraction for AI-powered job analysis against a candidate's profile.</summary>
+public interface IAnalysisService
+{
+    Task<AlignmentResult>  AnalyseAlignmentAsync         (UserProfile profile, string description, string? role, string? company);
+    Task<SkillsResult>     AnalyseSkillsAsync            (UserProfile profile, string description, string? role, string? company);
+    Task<GapsResult>       AnalyseGapsAsync              (UserProfile profile, string description, string? role, string? company);
+    Task<QuestionsResult>  AnalyseQuestionsToAskAsync    (UserProfile profile, string description, string? role, string? company);
+    Task<QuestionsResult>  AnalyseInterviewQuestionsAsync(UserProfile profile, string description, string? role, string? company);
+}

--- a/docs/plans/job-analysis.md
+++ b/docs/plans/job-analysis.md
@@ -252,7 +252,7 @@ Score is 1–5. `reasoning` is one sentence.
 
 | # | Item | Status |
 |---|---|---|
-| 6 | Add `IAnalysisService` + `ClaudeAnalysisService` in `Services/` | — |
+| 6 | Add `IAnalysisService` + `ClaudeAnalysisService` in `Services/` | Done |
 | 7 | Add `AnalysisController` at `/api/analyse` with 5 content-scoped endpoints (body: `description` + optional `role`/`company`); `[Authorize(Policy = "AiEnabled")]` + demo-block + shared `"analyse"` 5/min-per-IP policy | — |
 | 8 | Register `ClaudeAnalysisService` in `Program.cs` | — |
 | 8a | `AnalysisControllerTests` — mocks `IAnalysisService`; 400 gates, 403 demo, 502 on `AnalysisFormatException`, 200 happy path | — |
@@ -266,6 +266,10 @@ Score is 1–5. `reasoning` is one sentence.
 ### For the Analysis build (Steps 6–10)
 - `Anthropic:ApiKey` is shared with the auto-fill parsing feature — no duplicate config key needed.
 - Tests: mock `IAnalysisService` in controller tests; no live Claude calls in CI.
+
+### Step 6 polish (before Step 7)
+- **Prompt quality:** all 5 prompts in `ClaudeAnalysisConfig.cs` are placeholder quality — marked with a `TODO` comment. Dedicate a session to test each against real job descriptions and iterate before shipping.
+- **Shared Claude helper refactor:** `ClaudeParsingService` and `ClaudeAnalysisService` both duplicate `ExtractJson`. `ClaudeParsingService` also has `LogContractIssues` (logs unexpected/null keys to help tune prompts) that `ClaudeAnalysisService` lacks. Consider extracting both into a shared internal static helper (e.g. `ClaudeResponseHelper`) and adding contract-issue logging to the analysis service.
 
 ### Deferred / follow-up work
 - **Demo profile reset (pairs with D16):** the demo user can edit their seeded profile, so the periodic demo-data reset + login re-seed (Demo/Auth step 2) must be extended to cover `UserProfile` — add the sample profile to `DemoSeed` and include it in the reset path.

--- a/docs/plans/job-analysis.md
+++ b/docs/plans/job-analysis.md
@@ -203,9 +203,9 @@ All endpoints:
 
 **Alignment**
 ```json
-{ "score": 3, "reasoning": "Strong frontend match; limited backend exposure." }
+{ "score": 3, "reasoning": "Strong frontend match; limited backend exposure.", "concern": null }
 ```
-Score is 1–5. `reasoning` is one sentence.
+Score is 1–5. `reasoning` is one sentence. `concern` is `null` for a genuine listing, else a short not-a-job note (soft, non-refusing) — see the Profile Conditions expansion below.
 
 **Skills** — 5–8 items
 ```json
@@ -258,6 +258,65 @@ Score is 1–5. `reasoning` is one sentence.
 | 8a | `AnalysisControllerTests` — mocks `IAnalysisService`; 400 gates, 403 demo, 502 on `AnalysisFormatException`, 200 happy path | — |
 | 9 | Add analysis UI to Job Detail page — 5 independent buttons; pre-fill `description` from the job (prompt if empty); each shows its own result inline | — |
 | 10 | Add ad-hoc triage entry point — paste a description, Alignment only | — |
+
+---
+
+## Profile Conditions (Expansion — added 2026-07-12)
+
+Adds a "What I'm looking for" dimension to the profile — the user's **conditions/preferences**, distinct from **background**. Alignment analysis reads them so it answers "do you *want* this job?" not just "*can* you do it?". Modelled on the reference screener's "My Conditions". **Not started**; spans backend + frontend + the alignment prompt. Reopens Profile (previously "done" for background only).
+
+### Decisions
+
+| Decision | Reasoning |
+|---|---|
+| Profile = Background + Conditions (global, not per-role) | Conditions apply across all target roles, not per-role; `TargetRoles` stays `string[]` and heads a new "What I'm looking for" section. Per-role conditions rejected — rare need, large model/UI/prompt cost |
+| New condition fields: `WorkModes`, `ContractTypes`, `SalaryExpectation`, `PreferredLocations`, `AdditionalConditions` | Structure the filterable conditions (mode/contract/salary/location) for consistent hard signals; one free-text field absorbs nuance that resists structure |
+| Experience level → free text, not a structured field | Seniority is fuzzy and often role-dependent; an enum would fight reality. Reference treated junior-only as a hard filter — a soft free-text note fits this project better |
+| `WorkModes` reuses existing `WorkMode` enum (`OnSite`/`Remote`/`Hybrid`), multi-select | Remote is a work-mode, not a location — keeps geography and remote orthogonal (no "Remote country" hack) |
+| `ContractTypes` = unordered *acceptable set* (new enum) | Set answers "is this type acceptable?" — enough for alignment. Ranked preference deferred (nicer signal, more UI, low payoff now). Enum: `FullTimePermanent`, `FullTimeContract`, `PartTime`, `Casual`, `Internship`, `Temporary` |
+| `SalaryExpectation` = min floor only | Expectation is a floor; "any paid" = unset. Min+max range deferred. Owned object `{ MinAmount int?, Currency, Period }`, whole object nullable. Currency ISO 4217 alpha-3 (`^[A-Z]{3}$`); `SalaryPeriod` enum `Annual`/`Monthly`/`Hourly` |
+| `PreferredLocations` = `[{ Country, Areas[] }]`; empty `Areas` = anywhere in country | Country ISO-2 (reuse `^[A-Z]{2}$`) is a short autocomplete list — fixes "list too long"; `Areas` optional loose text (the infinite list stays unstructured). Multiple areas per country allowed. Cross-country regions ("Europe") go in free text, not a continent grouping |
+| `AdditionalConditions` = free text (`text`, max 500), HTML-rejected | Catch-all: experience level, "unpaid only if exceptional", region nuance. 500 fits a few preference notes, not an essay. Reject markup via the same inline `<[a-zA-Z/]` regex `ParseListingRequest` uses (no reusable attribute exists — it's an `IValidatableObject` check in `ProfileDTO.Validate()`) |
+| Conditions are optional — analysis gate unchanged | Requiring conditions would block a quick alignment run; they enrich output when present. The D9 profile-minimum stays background-only |
+| Only Alignment (of the 5) reads conditions | The other four are background-only (skills/gaps/interview prep); conditions are about fit/desire, which is Alignment's job |
+| Alignment gains soft `concern: string?` (not-a-job detection) | Surfaces "looks like a CV service / scam / unclear listing" without refusing — score + reasoning still return, the user decides. Non-strict by choice (some users want unclear listings). Threshold/wording tuned in the Step 6 prompt-polish session |
+
+### New fields (on `UserProfile`, `ProfileDTO`, `ProfileResponseDto`)
+
+| Field | Type | Storage (mirrors) |
+|---|---|---|
+| `WorkModes` | `List<WorkMode>` | JSONB list |
+| `ContractTypes` | `List<ContractType>` | JSONB list |
+| `SalaryExpectation` | `SalaryExpectation?` (owned) | JSONB (like `WorkingRights`) |
+| `PreferredLocations` | `List<PreferredLocationEntry>` | JSONB owned (like `WorkingRightEntry`) |
+| `AdditionalConditions` | `string?` | `text` column |
+
+**New enums** (`Models/Enums/`): `ContractType` (`FullTimePermanent`, `FullTimeContract`, `PartTime`, `Casual`, `Internship`, `Temporary`); `SalaryPeriod` (`Annual`, `Monthly`, `Hourly`).
+
+**New entry classes** (`Models/`, DataAnnotations style like `WorkingRightEntry.cs`):
+- `SalaryExpectation` — `MinAmount int?` (`[Range(0, MaxSalaryAmount)]`), `Currency string` (`^[A-Z]{3}$`), `Period SalaryPeriod`.
+- `PreferredLocationEntry` — `Country string` (required, `^[A-Z]{2}$`), `Areas List<string>` (optional; each item ≤ `MaxProfileLocationAreaItemLength`).
+
+### Validation constants (new)
+
+- Counts: `MaxProfileWorkModesCount` 3, `MaxProfileContractTypesCount` 6, `MaxProfileLocationsCount` 20, `MaxProfileLocationAreasCount` 10.
+- Lengths: `MaxProfileLocationAreaItemLength` 100, `MaxProfileAdditionalConditionsLength` 500.
+- Salary: `MaxSalaryAmount` (e.g. 100_000_000); currency regex `^[A-Z]{3}$` inline on the entry.
+
+### Steps (not started)
+
+| # | Item | Status |
+|---|---|---|
+| C1 | `ValidationConstants` + `ContractType`/`SalaryPeriod` enums + `PreferredLocationEntry`/`SalaryExpectation` classes | — |
+| C2 | `UserProfile` entity — add the 5 fields | — |
+| C3 | Migration (new `text` + JSONB columns) | — |
+| C4 | `ProfileDTO` + `ProfileResponseDto` — validation + `ToProfile`/`ApplyTo`/`ToResponseDto` wiring | — |
+| C5 | `ProfileDTOTests` — new-field validation (currency/country regex, count caps, salary range, `AdditionalConditions` HTML-reject) | — |
+| C6 | `FormatUserMessage` + `AlignmentPrompt` + Alignment model `concern` (the analysis payoff) | — |
+| C7 | Frontend profile form — conditions section + country/currency suggestion lists | — |
+| C8 | Frontend alignment display — show `concern` when present | — |
+
+Prompt-quality polish for the reworked `AlignmentPrompt` + the `concern` threshold folds into the existing Step 6 prompt-polish session.
 
 ---
 

--- a/docs/plans/job-analysis.md
+++ b/docs/plans/job-analysis.md
@@ -308,9 +308,9 @@ Adds a "What I'm looking for" dimension to the profile — the user's **conditio
 | # | Item | Status |
 |---|---|---|
 | C1 | `ValidationConstants` + `ContractType`/`SalaryPeriod` enums + `PreferredLocationEntry`/`SalaryExpectation` classes | Done |
-| C2 | `UserProfile` entity — add the 5 fields | — |
-| C3 | Migration (new `text` + JSONB columns) | — |
-| C4 | `ProfileDTO` + `ProfileResponseDto` — validation + `ToProfile`/`ApplyTo`/`ToResponseDto` wiring | — |
+| C2 | `UserProfile` entity — add the 5 fields | Done |
+| C3 | Migration (new `text` + JSONB columns) | Done |
+| C4 | `ProfileDTO` + `ProfileResponseDto` — validation + `ToProfile`/`ApplyTo`/`ToResponseDto` wiring | Done |
 | C5 | `ProfileDTOTests` — new-field validation (currency/country regex, count caps, salary range, `AdditionalConditions` HTML-reject) + `WorkingRightEntry` omitted-`Status` now fails (nullable+`[Required]` fix in C1) | — |
 | C6 | `FormatUserMessage` + `AlignmentPrompt` + Alignment model `concern` (the analysis payoff) | — |
 | C7 | Frontend profile form — conditions section + country/currency suggestion lists | — |

--- a/docs/plans/job-analysis.md
+++ b/docs/plans/job-analysis.md
@@ -307,11 +307,11 @@ Adds a "What I'm looking for" dimension to the profile — the user's **conditio
 
 | # | Item | Status |
 |---|---|---|
-| C1 | `ValidationConstants` + `ContractType`/`SalaryPeriod` enums + `PreferredLocationEntry`/`SalaryExpectation` classes | — |
+| C1 | `ValidationConstants` + `ContractType`/`SalaryPeriod` enums + `PreferredLocationEntry`/`SalaryExpectation` classes | Done |
 | C2 | `UserProfile` entity — add the 5 fields | — |
 | C3 | Migration (new `text` + JSONB columns) | — |
 | C4 | `ProfileDTO` + `ProfileResponseDto` — validation + `ToProfile`/`ApplyTo`/`ToResponseDto` wiring | — |
-| C5 | `ProfileDTOTests` — new-field validation (currency/country regex, count caps, salary range, `AdditionalConditions` HTML-reject) | — |
+| C5 | `ProfileDTOTests` — new-field validation (currency/country regex, count caps, salary range, `AdditionalConditions` HTML-reject) + `WorkingRightEntry` omitted-`Status` now fails (nullable+`[Required]` fix in C1) | — |
 | C6 | `FormatUserMessage` + `AlignmentPrompt` + Alignment model `concern` (the analysis payoff) | — |
 | C7 | Frontend profile form — conditions section + country/currency suggestion lists | — |
 | C8 | Frontend alignment display — show `concern` when present | — |

--- a/docs/plans/job-analysis.md
+++ b/docs/plans/job-analysis.md
@@ -299,7 +299,7 @@ Adds a "What I'm looking for" dimension to the profile — the user's **conditio
 
 ### Validation constants (new)
 
-- Counts: `MaxProfileWorkModesCount` 3, `MaxProfileContractTypesCount` 6, `MaxProfileLocationsCount` 20, `MaxProfileLocationAreasCount` 10.
+- Counts: `MaxProfileWorkModesCount` 3, `MaxProfileContractTypesCount` 6, `MaxProfileLocationsCount` 10, `MaxProfileLocationAreasCount` 10.
 - Lengths: `MaxProfileLocationAreaItemLength` 100, `MaxProfileAdditionalConditionsLength` 500.
 - Salary: `MaxSalaryAmount` (e.g. 100_000_000); currency regex `^[A-Z]{3}$` inline on the entry.
 

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -111,7 +111,7 @@ All planned steps complete. See `docs/plans/demo-auth-features.md` for full deta
 | Dashboard / Analytics | Funnel, response rate, weekly chart, stale jobs | Done |
 | Interview reminder email | Scheduled job emails user day-before interviewAt via IEmailService | Early planning |
 | Stale application indicator | `StaleIndicator` component — amber Clock icon + tooltip in jobs list and Kanban card; `staleDaysSince` helper extracted in `dashboardUtils.ts` | Done |
-| Job analysis | `UserProfile` table + 5 AI analysis endpoints + detail page UI | Profile (Steps 1–5, backend + `/profile` page + all suggestion lists) done, incl. tests. Analysis (Steps 6–10: `IAnalysisService`, `AnalysisController`, detail-page UI, ad-hoc triage) not started. See `docs/plans/job-analysis.md`. |
+| Job analysis | `UserProfile` table + 5 AI analysis endpoints + detail page UI | Profile (Steps 1–5) done. Step 6 done: `IAnalysisService`, `ClaudeAnalysisService`, `ClaudeAnalysisConfig`, `AnalysisModels`. Next: polish Step 6 (prompt quality + `ExtractJson`/`LogContractIssues` shared helper refactor), then Steps 7–10. See `docs/plans/job-analysis.md`. |
 | Company verification integration | Wire `GET /verify` into job create/edit UI; see `docs/company-verification-api-reference.md` | Pending |
 | Preferences PATCH refactor | `PUT /api/account/preferences` → `PATCH` with merge semantics | Postponed |
 | Job application rating API | Crowdsourced company ratings; separate product; scoring weights not finalized | Early planning |


### PR DESCRIPTION
## Summary

Adds a "What I'm looking for" section to the candidate profile and the first AI analysis service behind it. `UserProfile`, `ProfileDTO`, and `ProfileResponseDto` gain five new fields — preferred work modes, acceptable contract types, a salary floor, preferred locations, and a free-text notes field — each stored as JSONB via a new migration. A new `IAnalysisService` / `ClaudeAnalysisService` calls Claude to score how well a job matches a profile and to generate skill lists, gaps, and interview questions (Step 6 of the job-analysis plan in `docs/plans/job-analysis.md`).

The branch also carries a batch of Claude Code tooling work done in the same session: three new PreToolUse hooks (co-author guard, fetch guard, and an allowlist guard for the GitHub CLI), an expanded `settings.json` permission set, six new skills (`git-commit`, `issue-publish`, `label-setup`, `plan-impl`, `plan-product`, `plan-verify`, `pr-publish`), and the GitHub CLI added to the devcontainer.

## Notable decisions

- Conditions live on the profile as a whole, not per role. `TargetRoles` already answers "where"; conditions answer "what kind of job", and per-role conditions would need separate storage and UI for a case judged rare enough to skip.
- Experience level stayed free text (`AdditionalConditions`) instead of a structured enum, since seniority is fuzzy and often role-dependent.
- Of the five planned analysis endpoints, only Alignment reads the new conditions — the other four (skills, gaps, questions) are about capability, not fit, so scope stayed narrow.
- Prompt text in `ClaudeAnalysisConfig` is marked placeholder quality (see the `TODO`); polishing against real job descriptions is deferred to a follow-up session per `docs/plans/job-analysis.md`.
- The hooks/skills tooling changes are unrelated to the profile work but landed on this branch because they came out of the same working session — worth splitting into a separate PR if that matters for review.

## Test plan

- `dotnet build` passes.
- `ProfileDTOTests` do not yet cover the five new fields (currency/country regex, count caps, salary range, HTML rejection on `AdditionalConditions`) — that's Step C5 in the plan, still open.
- `ClaudeAnalysisService` has no tests yet and isn't wired into a controller in this branch, so there's nothing to exercise end-to-end. `AnalysisControllerTests` land with the controller in the next step.
- The new hooks were not run against their blocked/allowed command forms as part of this PR — worth a manual pass before relying on them.
